### PR TITLE
Remove WSL warning for now

### DIFF
--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1355,14 +1355,6 @@ impl<A: Auth> ConversationActor<A> {
                             available_commands,
                         })
                         .await;
-
-                    // https://github.com/openai/codex/blob/main/docs/faq.md#does-it-work-on-windows
-                    #[cfg(target_os = "windows")]
-                    client
-                        .send_agent_text(
-                            "For best performance, run Codex in Windows Subsystem for Linux (WSL2)",
-                        )
-                        .await;
                 });
             }
             ConversationMessage::Prompt {


### PR DESCRIPTION
This turned out to not look great. Ideally we have other mechanisms in the protocol for messages like this that the clients can handle better.
