### PR TITLE
fix: esm require in npm binary

### DIFF
--- a/npm/bin/codex-acp.js
+++ b/npm/bin/codex-acp.js
@@ -3,6 +3,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
 
 // Map Node.js platform/arch to package names
 function getPlatformPackage() {
@@ -47,6 +48,7 @@ function getBinaryPath() {
 
   try {
     // Try to resolve the platform-specific package
+    const require = createRequire(import.meta.url);
     const packagePath = require.resolve(`${packageName}/package.json`);
     const binaryPath = join(dirname(packagePath), "bin", binaryName);
 
@@ -54,6 +56,7 @@ function getBinaryPath() {
       return binaryPath;
     }
   } catch (e) {
+    console.error(`Error resolving package: ${e}`);
     // Package not found
   }
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zed-industries/codex-acp",
   "version": "0.3.3",
+  "type": "module",
   "description": "An ACP-compatible coding agent powered by Codex",
   "license": "Apache-2.0",
   "author": "Zed <hi@zed.dev>",

--- a/npm/publish/create-platform-packages.sh
+++ b/npm/publish/create-platform-packages.sh
@@ -62,7 +62,7 @@ for target in "${!platforms[@]}"; do
   fi
 
   # Make binary executable (important for Unix-like systems)
-  chmod +x "${pkg_dir}/bin/codex-acp${ext}" 2>/dev/null || true
+  chmod +x "${pkg_dir}/bin/codex-acp${ext}" 2>/dev/null || echo "Failed to make binary executable"
 
   # Create package.json from template
   export PACKAGE_NAME="$pkg_name"


### PR DESCRIPTION
This fixes the esm script to properly create a `require` obejct since it is not global, like in commonjs