### PR TITLE
fix: add bin field to platform-specific npm package to ensure EACCES

### DIFF
--- a/npm/publish/create-platform-packages.sh
+++ b/npm/publish/create-platform-packages.sh
@@ -76,6 +76,13 @@ for target in "${!platforms[@]}"; do
 
   envsubst < "$TEMPLATE_PATH" > "${pkg_dir}/package.json"
 
+  # Update bin field for Windows to include .exe extension
+  if [[ "$os" == "windows" ]]; then
+    # Use sed to update the bin path in package.json
+    sed -i.bak 's|"./bin/codex-acp"|"./bin/codex-acp.exe"|' "${pkg_dir}/package.json"
+    rm "${pkg_dir}/package.json.bak"
+  fi
+
   echo "   ✓ Created package: ${pkg_name}"
 done
 

--- a/npm/template/package.json
+++ b/npm/template/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/zed-industries/codex-acp"
   },
+  "bin": {
+    "codex-acp": "./bin/codex-acp"
+  },
   "os": [
     "${OS}"
   ],


### PR DESCRIPTION
Updates the packaging process for platform-specific npm packages to fix EACCES errors.

* Added a `bin` field to the `package.json` template to specify the path to the `codex-acp` executable.
* Find/replace the above for Windows builds