### PR TITLE
Add support for custom model provider and handle non-delta model outputs

### DIFF
--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -286,7 +286,11 @@ impl Agent for CodexAgent {
             self.auth_manager.clone(),
             self.client_capabilities.clone(),
             config.clone(),
-            self.model_presets.clone(),
+            crate::conversation::ConversationModelContext {
+                model_presets: self.model_presets.clone(),
+                model_provider: config.model_provider.clone(),
+                model: config.model.clone(),
+            },
         ));
         let load = conversation.load().await?;
 


### PR DESCRIPTION
### Description
This PR adds:
1. support for ["custom model provider"](https://github.com/openai/codex/blob/main/docs/config.md#model_providers) authentication option, closes https://github.com/zed-industries/zed/issues/40292
> I'm not sure this is the best or complete way to wire up a custom provider — happy to change the approach, any suggestions welcome.

2. conversation event handling to support models that emit full (non-delta) messages and reasoning blocks.

### Testing

Tested with `aigateway` as a provider
```toml
profile = "aigateway"

[profiles.aigateway]
model = "openai/gpt-5-mini"
model_provider = "aigateway"

[model_providers.aigateway]
base_url = "https://ai-gateway.vercel.sh/v1"
env_key = "AI_GATEWAY_API_KEY"
name = "aigateway"
wire_api = "chat"
```

Logs:
```bash
2025-10-22T10:51:05.871319Z DEBUG reqwest::connect: starting new connection: https://ai-gateway.vercel.sh/
2025-10-22T10:51:05.888783Z DEBUG hyper_util::client::legacy::connect::http: connecting to 76.76.21.241:443
2025-10-22T10:51:05.889196Z DEBUG hyper_util::client::legacy::connect::http: connected to 76.76.21.241:443
2025-10-22T10:51:07.273613Z  INFO codex_otel::otel_event_manager: event.name="codex.api_request" event.timestamp=2025-10-22T10:51:07.273Z conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=1402 http.response.status_code=200 attempt=1
2025-10-22T10:51:07.280032Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:07.280Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=4
2025-10-22T10:51:20.635622Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.635Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=13355
2025-10-22T10:51:20.639854Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.639Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=4
2025-10-22T10:51:20.649002Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.648Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=8
2025-10-22T10:51:20.649050Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.649Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.671920Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.671Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=22
2025-10-22T10:51:20.672097Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.672Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.672244Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.672Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.686594Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.686Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=14
2025-10-22T10:51:20.696912Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.696Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=10
2025-10-22T10:51:20.718441Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.718Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=21
2025-10-22T10:51:20.722151Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.722Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=3
2025-10-22T10:51:20.737724Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.737Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=15
2025-10-22T10:51:20.847791Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.847Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=110
2025-10-22T10:51:20.847851Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.847Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.847934Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.847Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.847957Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.847Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.848082Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.848Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.848104Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.848Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=0
2025-10-22T10:51:20.980516Z  INFO codex_otel::otel_event_manager: event.name="codex.sse_event" event.timestamp=2025-10-22T10:51:20.980Z event.kind=message conversation.id=019a0b8b-3cf9-7ef2-ab52-2898464ce539 app.version=0.0.0 auth_mode="ApiKey" terminal.type=vscode/1.105.1 model=openai/gpt-5-mini slug=openai/gpt-5-mini duration_ms=132
2025-10-22T10:51:20.982660Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", ai-gateway.vercel.sh)
2025-10-22T10:51:20.983011Z DEBUG codex_core::codex: Output item item=Message { id: None, role: "assistant", content: [OutputText { text: "Quiet agents hear\nguiding hands through night's soft fog\nwe find morning's path" }] }
2025-10-22T10:51:20.983297Z  INFO codex_acp::conversation: Agent message (non-delta) received: "Quiet agents hear\nguiding hands through night's soft fog\nwe find morning's path"
2025-10-22T10:51:20.983784Z  INFO codex_acp::conversation: Task completed successfully after 4 events. Last agent message: Some("Quiet agents hear\nguiding hands through night's soft fog\nwe find morning's path")
Quiet agents hear
guiding hands through night's soft fog
we find morning's pathQuiet agents hear

──────────────────────────────────────────────────
```

<img width="2400" height="2250" alt="image" src="https://github.com/user-attachments/assets/47f194d1-eb90-4802-bd2b-263305675108" />
