### PR TITLE
Fix ChatGPT Authentication requiring login every time agent starts

### DIFF
--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -16,7 +16,7 @@ use codex_core::{
     },
     protocol::SessionSource,
 };
-use codex_login::{CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR};
+use codex_login::{AuthMode, CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR};
 use codex_protocol::ConversationId;
 use std::{
     cell::RefCell,
@@ -157,12 +157,21 @@ impl Agent for CodexAgent {
         &self,
         request: AuthenticateRequest,
     ) -> Result<AuthenticateResponse, Error> {
-        // Check before starting login flow if already authenticated
-        if self.auth_manager.auth().is_some() {
-            return Ok(AuthenticateResponse { meta: None });
-        }
-
         let auth_method = CodexAuthMethod::try_from(request.method_id)?;
+
+        // Check before starting login flow if already authenticated with the same method
+        if let Some(auth) = self.auth_manager.auth() {
+            match (auth.mode, auth_method) {
+                (
+                    AuthMode::ApiKey,
+                    CodexAuthMethod::CodexApiKey | CodexAuthMethod::OpenAiApiKey,
+                )
+                | (AuthMode::ChatGPT, CodexAuthMethod::ChatGpt) => {
+                    return Ok(AuthenticateResponse { meta: None });
+                }
+                _ => {}
+            }
+        }
 
         match auth_method {
             CodexAuthMethod::ChatGpt => {


### PR DESCRIPTION
I use the codex-acp with codecompanion within neovim and everytime I attempt to use codex with it, I have to log in to ChatGPT in the browser. 

I noticed a similar issue in https://github.com/zed-industries/codex-acp/issues/68. 

From what I understand with how codecompanion calls `authenticate` after initialization. This PR adds a guard check so that it will check to see if any existing authentication has been made before starting the login flow.

I know that PR #59 was merged which attempted to fix the issue. 

I did notice that in #59 there was a bit of code that returns a `Ok(AuthenticatedResponse...` that was removed when the PR was merged in and also acts as a guard for just the ChatGPT auth method.

Not sure why it was removed from the PR. 

```rs
if matches!(
      self.auth_manager.auth(),
      Some(auth) if auth.mode == AuthMode::ChatGPT
  ) {
      return Ok(AuthenticateResponse { meta: None });
  }
```

The guard check in the PR is a lot simpler. 

With this fix, I can call up codex-acp and not have to authenticate every time.


 