### PR TITLE
Allow passing Codex config overrides at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "agent-client-protocol",
  "anyhow",
  "async-trait",
+ "clap",
  "codex-apply-patch",
  "codex-arg0",
  "codex-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 regex-lite = "0.1.8"
 shlex = "1.3.0"
+clap = "4.5.51"
 
 [lints.rust]
 let-underscore = "warn"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
+use clap::Parser;
 use codex_arg0::arg0_dispatch_or_else;
 use codex_common::CliConfigOverrides;
 
 fn main() -> Result<()> {
     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
-        codex_acp::run_main(codex_linux_sandbox_exe, CliConfigOverrides::default()).await?;
+        let cli_config_overrides = CliConfigOverrides::parse();
+        codex_acp::run_main(codex_linux_sandbox_exe, cli_config_overrides).await?;
         Ok(())
     })
 }


### PR DESCRIPTION
Sometimes Codex configuration need to be modified at runtime, such as enabling Codex to read environment variables containing [TOKEN](https://github.com/openai/codex/blob/main/docs/config.md#shell_environment_policy) (e.g., GH_TOKEN). 
This allows Codex to better work with other CLI tools, while preventing accidental exposure of sensitive environment variables.