### PR TITLE
Better support third-party providers

### DIFF
--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1630,6 +1630,20 @@ impl<A: Auth> ConversationActor<A> {
             ModelId(self.config.model.clone().into())
         });
 
+        // If the user is using a custom provider, don't return the list
+        if self.config.model_provider_id != "openai" {
+            return Ok(SessionModelState {
+                available_models: vec![ModelInfo {
+                    model_id: current_model_id.clone(),
+                    name: format!("{current_model_id} ({})", self.config.model_provider.name),
+                    description: None,
+                    meta: None,
+                }],
+                current_model_id,
+                meta: None,
+            });
+        }
+
         let available_models = MODEL_PRESETS
             .iter()
             .flat_map(|preset| {


### PR DESCRIPTION
If we aren't using the default provider, don't prompt the login flows.

Also, doesn't return the default models as they wouldn't be usable by
that provider anyway.

Closes: #43
