### PR TITLE
fix: pass the sandbox executable name to the codex-cli binary to allow the agent to use the sandbox

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub static ACP_CLIENT: OnceLock<Arc<AgentSideConnection>> = OnceLock::new();
 ///
 /// If unable to parse the config or start the program.
 pub async fn run_main(
-    _codex_linux_sandbox_exe: Option<PathBuf>,
+    codex_linux_sandbox_exe: Option<PathBuf>,
     cli_config_overrides: CliConfigOverrides,
 ) -> IoResult<()> {
     // Install a simple subscriber so `tracing` output is visible.
@@ -45,7 +45,12 @@ pub async fn run_main(
         )
     })?;
 
-    let config = Config::load_with_cli_overrides(cli_kv_overrides, ConfigOverrides::default())
+    let config_overrides = ConfigOverrides {
+        codex_linux_sandbox_exe,
+        ..ConfigOverrides::default()
+    };
+
+    let config = Config::load_with_cli_overrides(cli_kv_overrides, config_overrides)
         .await
         .map_err(|e| {
             std::io::Error::new(


### PR DESCRIPTION
Closes the issue https://github.com/zed-industries/codex-acp/issues/93 - there's more context regarding the issue there

the root cause was that no binary was passed to codex-cli for the sandboxing commands, which should be the path of codex-cli itself. based on arg0 it behaves differently and when `codex-linux-sandbox` is passed it does the expected linux sandbox operations.

I tested this manually by adding the newly built debug binary as a custom agent to zed. it was able to do normal tool calls and edit a file