### PR TITLE
codex-acp: add /undo slash command

### DIFF
--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1359,7 +1359,9 @@ impl TaskState {
                 } else {
                     "Undo failed.".to_string()
                 };
-                client.send_agent_text(event.message.unwrap_or(fallback)).await;
+                client
+                    .send_agent_text(event.message.unwrap_or(fallback))
+                    .await;
             }
             EventMsg::StreamError(StreamErrorEvent {
                 message,
@@ -2334,7 +2336,11 @@ mod tests {
         )?;
 
         let notifications = client.notifications.lock().unwrap();
-        assert_eq!(notifications.len(), 2, "notifications don't match {notifications:?}");
+        assert_eq!(
+            notifications.len(),
+            2,
+            "notifications don't match {notifications:?}"
+        );
         assert!(matches!(
             &notifications[0].update,
             SessionUpdate::AgentMessageChunk(ContentChunk {


### PR DESCRIPTION
Adds built-in /undo support in codex-acp by mapping the slash command to Op::Undo and surfacing UndoStarted/UndoCompleted events to ACP clients. Includes unit test coverage.