### PR TITLE
Fix location issue for search tool calls

### DIFF
--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1287,7 +1287,6 @@ fn parse_command_tool_call(parsed_cmd: Vec<ParsedCommand>, cwd: &Path) -> ParseC
                     (Some(query), None) => format!("Search {query}"),
                     _ => format!("Search {cmd}"),
                 });
-                cmd_path = path.map(PathBuf::from);
                 kind = ToolKind::Search;
             }
             ParsedCommand::Unknown { cmd } => {


### PR DESCRIPTION
The path returned from a parsed search command isn't correct. Just skipping this one since it isn't a proper "location" in the ACP sense anyway and is mostly for displaying a title/description.
