### PR TITLE
Allow providers to provide models as well

### DIFF
--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -1799,24 +1799,9 @@ impl<A: Auth> ConversationActor<A> {
         } else {
             // If no preset found, return the current model string as-is
             let model_id = ModelId::new(self.get_current_model().await);
-            available_models.push(ModelInfo::new(
-                model_id.clone(),
-                if self.config.model_provider_id == "openai" {
-                    model_id.to_string()
-                } else {
-                    format!("{model_id} ({})", self.config.model_provider.name)
-                },
-            ));
+            available_models.push(ModelInfo::new(model_id.clone(), model_id.to_string()));
             model_id
         };
-
-        // If the user is using a custom provider, don't return the list
-        if self.config.model_provider_id != "openai" {
-            return Ok(SessionModelState::new(
-                current_model_id.clone(),
-                available_models,
-            ));
-        }
 
         available_models.extend(
             self.models_manager


### PR DESCRIPTION
Closes #119

Now that we've moved model management from a hard-coded list to the one managed by Codex in #111, we'll also just rely on it being a valid list here and allow those models to show up as well.
