### PR TITLE
Show mode selector when project is untrusted

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1950,6 +1950,21 @@ impl<A: Auth> ThreadActor<A> {
                 &preset.approval == self.config.approval_policy.get()
                     && &preset.sandbox == self.config.sandbox_policy.get()
             })
+            .or_else(|| {
+                // When the project is untrusted, the above code won't match
+                // since AskForApproval::UnlessTrusted is not part of the
+                // default presets. However, in this case we still want to show
+                // the mode selector, which allows the user to choose a
+                // different mode (which will set the project to be trusted)
+                // See https://github.com/zed-industries/zed/issues/48132
+                if self.config.active_project.is_untrusted() {
+                    APPROVAL_PRESETS
+                        .iter()
+                        .find(|preset| preset.id == "read-only")
+                } else {
+                    None
+                }
+            })
             .map(|preset| SessionModeId::new(preset.id))?;
 
         Some(SessionModeState::new(


### PR DESCRIPTION
See https://github.com/zed-industries/zed/issues/48132

This will make it so that we show the mode selector in case the user is in an untrusted project. Once the user chooses a different mode (`Default`/`Full Access`) we mark the project as trusted in `handle_set_mode`