### PR TITLE
Expose codex runtime session id in ACP session metadata

### DIFF
--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -100,17 +100,10 @@ impl CodexAgent {
     }
 
     fn runtime_session_meta(session_id: &SessionId) -> Meta {
-        let runtime_id = session_id.0.to_string();
-        Meta::from_iter([
-            (
-                "runtimeSessionId".to_owned(),
-                serde_json::Value::String(runtime_id.clone()),
-            ),
-            (
-                "codexSessionId".to_owned(),
-                serde_json::Value::String(runtime_id),
-            ),
-        ])
+        Meta::from_iter([(
+            "sessionId".to_owned(),
+            serde_json::Value::String(session_id.0.to_string()),
+        )])
     }
 
     fn get_thread(&self, session_id: &SessionId) -> Result<Rc<Thread>, Error> {


### PR DESCRIPTION
Excuse the two earlier PRs opened by accident by my clanker

If possible, I need a way to expose the codex session id. This PR attempts it through _meta

If you think it should be done in another way, I am happy to take it over and change it as well