### PR TITLE
Sanitize MCP server names containing whitespace

### DIFF
--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -144,6 +144,8 @@ impl CodexAgent {
                 McpServer::Http(McpServerHttp {
                     name, url, headers, ..
                 }) => {
+                    // Codex does not allow whitespace in MCP server names; replace with underscores.
+                    let name = name.replace(|c: char| c.is_whitespace(), "_");
                     new_mcp_servers.insert(
                         name,
                         McpServerConfig {
@@ -176,6 +178,8 @@ impl CodexAgent {
                     env,
                     ..
                 }) => {
+                    // Codex does not allow whitespace in MCP server names; replace with underscores.
+                    let name = name.replace(|c: char| c.is_whitespace(), "_");
                     new_mcp_servers.insert(
                         name,
                         McpServerConfig {


### PR DESCRIPTION
## Summary

Fixes #55

When an MCP server name contains spaces (or other whitespace), Codex fails to initialize it because the server name is used as a key that must not contain whitespace.

This PR sanitizes MCP server names in the adapter layer by replacing each whitespace character with an underscore before the name is passed to Codex. The fix is applied to both HTTP and Stdio server types.

## Changes

- `src/codex_agent.rs`: Replace whitespace in MCP server names with underscores for both `McpServer::Http` and `McpServer::Stdio` variants.

---
🤖 Generated with Claude Code