### PR TITLE
Compare discriminants when checking modes/permissions

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2434,8 +2434,10 @@ impl<A: Auth> ThreadActor<A> {
         let current_mode_id = APPROVAL_PRESETS
             .iter()
             .find(|preset| {
-                &preset.approval == self.config.permissions.approval_policy.get()
-                    && &preset.sandbox == self.config.permissions.sandbox_policy.get()
+                std::mem::discriminant(&preset.approval)
+                    == std::mem::discriminant(self.config.permissions.approval_policy.get())
+                    && std::mem::discriminant(&preset.sandbox)
+                        == std::mem::discriminant(self.config.permissions.sandbox_policy.get())
             })
             .or_else(|| {
                 // When the project is untrusted, the above code won't match


### PR DESCRIPTION
The APPROVAL_PRESETS have this shape:

    preset id="read-only" approval=OnRequest sandbox=ReadOnly { access: FullAccess, network_access: false }

    preset id="auto" approval=OnRequest sandbox=WorkspaceWrite { writable_roots: [], read_only_access: FullAccess, network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false }

    preset id="full-access" approval=Never sandbox=DangerFullAccess

However, the config permission sandbox, whenever a directory is trusted, has this shape:

    approval_policy=OnRequest
    sandbox_policy=WorkspaceWrite { writable_roots: [AbsolutePathBuf("/Users/jose/.codex/memories")], read_only_access: FullAccess, network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false }

As you can see, the WorkspaceWrite is not going to match, because the struct has some information filled in. Therefore, we only check the names themselves.

Closes #194.