### PR TITLE
Prefer local reads for .svelte files to avoid ACP stdio framing failures related to newlines

### DIFF
--- a/src/local_spawner.rs
+++ b/src/local_spawner.rs
@@ -147,6 +147,10 @@ impl AcpFs {
             ))
         }
     }
+
+    fn should_prefer_local_read(path: &std::path::Path) -> bool {
+        matches!(path.extension().and_then(std::ffi::OsStr::to_str), Some("svelte"))
+    }
 }
 
 impl codex_apply_patch::Fs for AcpFs {
@@ -155,6 +159,14 @@ impl codex_apply_patch::Fs for AcpFs {
             return StdFs.read_to_string(path);
         }
         let path = self.ensure_within_root(path)?;
+        // ACP stdio framing is newline-delimited JSON-RPC. If a client leaks raw
+        // Svelte buffer contents onto stdout, patch application can desynchronize.
+        // Prefer local reads for Svelte files as a targeted workaround.
+        if Self::should_prefer_local_read(&path)
+            && let Ok(contents) = StdFs.read_to_string(&path)
+        {
+            return Ok(contents);
+        }
         let (tx, rx) = std::sync::mpsc::channel();
         self.local_spawner.spawn(FsTask::ReadFile {
             session_id: self.session_id.clone(),
@@ -203,6 +215,9 @@ impl codex_core::codex::Fs for AcpFs {
             Ok(path) => path,
             Err(e) => return Box::pin(async move { Err(e) }),
         };
+        if Self::should_prefer_local_read(&path) {
+            return StdFs.file_buffer(&path, limit);
+        }
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.local_spawner.spawn(FsTask::ReadFileLimit {
             session_id: self.session_id.clone(),


### PR DESCRIPTION
This works around a transport issue seen when reading some .svelte files via ACP fs/read_text_file. In the failing cases, raw Svelte content can leak outside the newline-delimited JSON-RPC envelope, causing parser failures and follow-on tool call errors. To keep patch flows stable, AcpFs now falls back to local filesystem reads for .svelte files while continuing to use ACP-backed reads for other file types.

### Expected behavior:
When Codex reads a .svelte file through ACP fs/read_text_file, the client should return the file contents as a valid JSON-RPC response, with the Svelte source contained inside the JSON string. The ACP stream should remain synchronized, and patching should continue normally.

### Actual behavior:
The ACP stream becomes desynchronized while reading a .svelte file. See 
[Uploading acp-codex-log-with-error.txt…]()


In acp-codex-log-with-error.txt:22235, the parser reports this instead of a JSON-RPC object.:

failed to parse incoming message: expected value at line 1 column 12

...

and the raw incoming payload starts with leaked Svelte markup such as <thead class=\"bg-muted/20 text-xs text-muted-foreground uppercase\">

The leaked markup continues in subsequent log lines like acp-codex-log-with-error.txt:22243 and acp-codex-log-with-error.txt:22251, showing the file contents escaping the JSON envelope. After that, Codex starts reporting downstream tool-call failures such as Custom tool call output is missing in acp-codex-log-with-error.txt:32.