### PR TITLE
fix: avoid ACP apply_patch deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "codex-utils-cli",
  "heck",
  "itertools 0.14.0",
+ "piper",
  "regex-lite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ unused = "warn"
 [patch.crates-io]
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
+
+[dev-dependencies]
+piper = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 use agent_client_protocol::AgentSideConnection;
 use codex_core::config::{Config, ConfigOverrides};
 use codex_utils_cli::CliConfigOverrides;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::{io::Result as IoResult, rc::Rc};
@@ -17,6 +18,35 @@ mod prompt_args;
 mod thread;
 
 pub static ACP_CLIENT: OnceLock<Arc<AgentSideConnection>> = OnceLock::new();
+
+pub(crate) fn spawn_acp_io_task<F>(
+    thread_name: &str,
+    io_task: F,
+) -> IoResult<tokio::sync::oneshot::Receiver<IoResult<()>>>
+where
+    F: Future<Output = agent_client_protocol::Result<()>> + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let thread_name = thread_name.to_string();
+
+    std::thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            let result = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(std::io::Error::other)
+                .and_then(|runtime| {
+                    runtime
+                        .block_on(io_task)
+                        .map_err(|e| std::io::Error::other(format!("ACP I/O error: {e}")))
+                });
+            let _send_result = tx.send(result);
+        })
+        .map_err(std::io::Error::other)?;
+
+    Ok(rx)
+}
 
 /// Run the Codex ACP agent.
 ///
@@ -78,9 +108,10 @@ pub async fn run_main(
                 return Err(std::io::Error::other("ACP client already set"));
             }
 
-            io_task
-                .await
-                .map_err(|e| std::io::Error::other(format!("ACP I/O error: {e}")))
+            let io_task = spawn_acp_io_task("codex-acp-io", io_task)?;
+            io_task.await.map_err(|_| {
+                std::io::Error::other("ACP I/O thread shut down before reporting a result")
+            })?
         })
         .await?;
 

--- a/src/local_spawner.rs
+++ b/src/local_spawner.rs
@@ -260,3 +260,311 @@ impl LocalSpawner {
             .expect("Thread with LocalSet has shut down.");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        process::Command,
+        sync::Arc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use agent_client_protocol::{
+        Agent, AgentSideConnection, AuthenticateRequest, AuthenticateResponse,
+        ClientSideConnection, FileSystemCapabilities, Implementation, InitializeRequest,
+        InitializeResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+        NewSessionResponse, PromptRequest, PromptResponse, ReadTextFileResponse,
+        SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+        SetSessionModeResponse, StopReason,
+    };
+
+    use super::*;
+
+    const DEADLOCK_CHILD_ENV: &str = "CODEX_ACP_APPLY_PATCH_DEADLOCK_CHILD";
+    const DEADLOCK_CHILD_TEST: &str = "local_spawner::tests::apply_patch_verification_child";
+
+    #[test]
+    fn apply_patch_verification_does_not_deadlock_over_acp_fs() {
+        if std::env::var_os(DEADLOCK_CHILD_ENV).is_some() {
+            return;
+        }
+
+        let current_exe = std::env::current_exe().expect("resolve current test binary");
+        let mut child = Command::new(current_exe)
+            .arg("--exact")
+            .arg(DEADLOCK_CHILD_TEST)
+            .arg("--nocapture")
+            .env(DEADLOCK_CHILD_ENV, "1")
+            .spawn()
+            .expect("spawn deadlock child");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().expect("poll deadlock child") {
+                assert!(status.success(), "child exited with {status}");
+                return;
+            }
+
+            if Instant::now() >= deadline {
+                drop(child.kill());
+                drop(child.wait());
+                panic!("child timed out; apply_patch ACP fs roundtrip deadlocked");
+            }
+
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    #[test]
+    fn apply_patch_verification_child() {
+        if std::env::var_os(DEADLOCK_CHILD_ENV).is_none() {
+            return;
+        }
+
+        reproduce_apply_patch_roundtrip();
+    }
+
+    fn reproduce_apply_patch_roundtrip() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        let local_set = tokio::task::LocalSet::new();
+
+        runtime.block_on(local_set.run_until(async move {
+            let client = TestClient::new();
+            let agent = TestAgent;
+            let root = std::env::temp_dir().join(format!("codex-acp-deadlock-{}", std::process::id()));
+            let session_id = SessionId::new("test-session");
+            let file_path = root.join("src/client.rs");
+            let (client_to_agent_rx, client_to_agent_tx) = piper::pipe(1024);
+            let (agent_to_client_rx, agent_to_client_tx) = piper::pipe(1024);
+            let (client_ready_tx, client_ready_rx) = std::sync::mpsc::channel();
+
+            std::fs::create_dir_all(file_path.parent().expect("parent dir"))
+                .expect("create test dirs");
+            client.add_file_content(file_path.clone(), "fn old() {}\n".to_string());
+
+            let _client_thread = thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build remote client runtime");
+                let local_set = tokio::task::LocalSet::new();
+
+                runtime.block_on(local_set.run_until(async move {
+                    let (_client_side, client_io_task) = ClientSideConnection::new(
+                        client,
+                        client_to_agent_tx,
+                        agent_to_client_rx,
+                        |fut| {
+                            tokio::task::spawn_local(fut);
+                        },
+                    );
+                    client_ready_tx.send(()).expect("signal remote client ready");
+                    client_io_task.await.expect("run remote client io task");
+                }));
+            });
+
+            client_ready_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("wait for remote client bootstrap");
+
+            let (agent_side, agent_io_task) = AgentSideConnection::new(
+                agent,
+                agent_to_client_tx,
+                client_to_agent_rx,
+                |fut| {
+                    tokio::task::spawn_local(fut);
+                },
+            );
+
+            ACP_CLIENT
+                .set(Arc::new(agent_side))
+                .expect("install ACP client for child");
+
+            let _agent_io = crate::spawn_acp_io_task("local-spawner-test-agent-io", agent_io_task)
+                .expect("spawn agent io thread");
+
+            tokio::task::yield_now().await;
+
+            let capabilities = Arc::new(Mutex::new(
+                ClientCapabilities::new().fs(FileSystemCapabilities::new().read_text_file(true)),
+            ));
+            let session_roots = Arc::new(Mutex::new(HashMap::from([(
+                session_id.clone(),
+                root.clone(),
+            )])));
+            let fs = AcpFs::new(
+                session_id,
+                capabilities,
+                LocalSpawner::new(),
+                session_roots,
+            );
+
+            let patch = "*** Begin Patch\n*** Update File: src/client.rs\n@@\n-fn old() {}\n+fn new() {}\n*** End Patch";
+            let argv = vec!["apply_patch".to_string(), patch.to_string()];
+            let result = codex_apply_patch::maybe_parse_apply_patch_verified(&argv, &root, &fs);
+
+            assert!(
+                matches!(result, codex_apply_patch::MaybeApplyPatchVerified::Body(_)),
+                "expected verified patch body, got {result:?}"
+            );
+        }));
+    }
+
+    #[derive(Clone)]
+    struct TestClient {
+        file_contents: Arc<Mutex<HashMap<PathBuf, String>>>,
+    }
+
+    impl TestClient {
+        fn new() -> Self {
+            Self {
+                file_contents: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn add_file_content(&self, path: PathBuf, content: String) {
+            self.file_contents.lock().unwrap().insert(path, content);
+        }
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl Client for TestClient {
+        async fn request_permission(
+            &self,
+            _arguments: agent_client_protocol::RequestPermissionRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::RequestPermissionResponse>
+        {
+            unimplemented!()
+        }
+
+        async fn write_text_file(
+            &self,
+            _arguments: WriteTextFileRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::WriteTextFileResponse> {
+            unimplemented!()
+        }
+
+        async fn read_text_file(
+            &self,
+            arguments: ReadTextFileRequest,
+        ) -> agent_client_protocol::Result<ReadTextFileResponse> {
+            let contents = self.file_contents.lock().unwrap();
+            let content = contents
+                .get(&arguments.path)
+                .cloned()
+                .unwrap_or_else(|| "default content".to_string());
+            Ok(ReadTextFileResponse::new(content))
+        }
+
+        async fn session_notification(
+            &self,
+            _args: agent_client_protocol::SessionNotification,
+        ) -> agent_client_protocol::Result<()> {
+            Ok(())
+        }
+
+        async fn create_terminal(
+            &self,
+            _args: agent_client_protocol::CreateTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::CreateTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn terminal_output(
+            &self,
+            _args: agent_client_protocol::TerminalOutputRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::TerminalOutputResponse> {
+            unimplemented!()
+        }
+
+        async fn kill_terminal(
+            &self,
+            _args: agent_client_protocol::KillTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::KillTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn release_terminal(
+            &self,
+            _args: agent_client_protocol::ReleaseTerminalRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::ReleaseTerminalResponse> {
+            unimplemented!()
+        }
+
+        async fn wait_for_terminal_exit(
+            &self,
+            _args: agent_client_protocol::WaitForTerminalExitRequest,
+        ) -> agent_client_protocol::Result<agent_client_protocol::WaitForTerminalExitResponse>
+        {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestAgent;
+
+    #[async_trait::async_trait(?Send)]
+    impl Agent for TestAgent {
+        async fn initialize(
+            &self,
+            arguments: InitializeRequest,
+        ) -> agent_client_protocol::Result<InitializeResponse> {
+            Ok(InitializeResponse::new(arguments.protocol_version)
+                .agent_info(Implementation::new("test-agent", "0.0.0").title("Test Agent")))
+        }
+
+        async fn authenticate(
+            &self,
+            _arguments: AuthenticateRequest,
+        ) -> agent_client_protocol::Result<AuthenticateResponse> {
+            Ok(AuthenticateResponse::default())
+        }
+
+        async fn new_session(
+            &self,
+            _arguments: NewSessionRequest,
+        ) -> agent_client_protocol::Result<NewSessionResponse> {
+            Ok(NewSessionResponse::new(SessionId::new("unused")))
+        }
+
+        async fn load_session(
+            &self,
+            _arguments: LoadSessionRequest,
+        ) -> agent_client_protocol::Result<LoadSessionResponse> {
+            Ok(LoadSessionResponse::new())
+        }
+
+        async fn set_session_mode(
+            &self,
+            _arguments: SetSessionModeRequest,
+        ) -> agent_client_protocol::Result<SetSessionModeResponse> {
+            Ok(SetSessionModeResponse::new())
+        }
+
+        async fn prompt(
+            &self,
+            _arguments: PromptRequest,
+        ) -> agent_client_protocol::Result<PromptResponse> {
+            Ok(PromptResponse::new(StopReason::EndTurn))
+        }
+
+        async fn cancel(
+            &self,
+            _arguments: agent_client_protocol::CancelNotification,
+        ) -> agent_client_protocol::Result<()> {
+            Ok(())
+        }
+
+        async fn set_session_config_option(
+            &self,
+            _args: SetSessionConfigOptionRequest,
+        ) -> agent_client_protocol::Result<SetSessionConfigOptionResponse> {
+            Ok(SetSessionConfigOptionResponse::new(vec![]))
+        }
+    }
+}


### PR DESCRIPTION
Clanker generated report, let me know if it's not clear enough:

## Summary
- move the ACP I/O loop onto its own dedicated thread/runtime instead of running it on the same local executor as tool execution
- add a regression test for `apply_patch` verification over ACP-backed filesystem reads
- keep the fix narrow to the local ACP runtime path

## Reliable repro
This PR now includes a deterministic repro in `src/local_spawner.rs`:
- test: `apply_patch_verification_does_not_deadlock_over_acp_fs`
- child entrypoint: `apply_patch_verification_child`

What the repro does:
1. Start a fake ACP client/server pair over pipes.
2. Serve file contents through `AcpFs` rather than the normal local filesystem.
3. Call `codex_apply_patch::maybe_parse_apply_patch_verified(...)` on a patch that updates an existing file.
4. Fail the parent test if the child does not finish within 5 seconds.

Why this is the right repro:
- it does not depend on `acpx`
- it exercises the actual problematic path in `codex-acp`
- it uses the same ACP-backed file-read roundtrip that `apply_patch` uses in real sessions

Behavior:
- before this fix: the child times out with `apply_patch ACP fs roundtrip deadlocked`
- after this fix: the child exits successfully and the test passes

## User-visible symptom
When `codex-acp` is connected to an ACP host that serves file contents over ACP, an `apply_patch` call that needs to verify an existing file can hang forever.

From the host side, the symptom looks like this:
1. `codex-acp` requests `fs/read_text_file`.
2. The host replies successfully with the file contents.
3. `codex-acp` never finishes the `apply_patch` turn.
4. No patch is applied, and the session appears stuck at the tool boundary.

That is the behavior I first saw in the wild. The host-specific details are not important to the bug; the important part is that ACP FS reads were working, but `codex-acp` stopped making progress after the response.

## Root cause
`ApplyPatchHandler` uses `codex_apply_patch::maybe_parse_apply_patch_verified(...)`, which can synchronously call back into `AcpFs::read_to_string()` while verifying the patch against current file contents.

Before this change, the agent-side ACP I/O loop was running on the same local executor as tool execution. That means:
- the tool handler can block waiting for an ACP FS response
- but the ACP I/O task that must receive and deliver that response is sharing the same execution lane
- so the tool can end up waiting on work that the runtime is no longer able to drive

In practice, that deadlocks `apply_patch` verification at the ACP filesystem boundary.

## Fix
Run the ACP I/O loop on its own dedicated OS thread with its own Tokio runtime instead of awaiting it directly on the main `LocalSet`.

That keeps ACP request/response handling alive even while a tool handler is inside a blocking ACP FS roundtrip.

## Validation
- `cargo test apply_patch_verification_does_not_deadlock_over_acp_fs -- --nocapture`
- `cargo test`
- `cargo fmt --check`
