### PR TITLE
Fix replay rendering for `exec_command` and `update_plan`

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4585,6 +4585,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_replay_update_plan_function_call_emits_plan_update() -> anyhow::Result<()> {
+        LocalSet::new()
+            .run_until(async {
+                let session_id = SessionId::new("test");
+                let client = Arc::new(StubClient::new());
+                let session_client =
+                    SessionClient::with_client(session_id, client.clone(), Arc::default());
+                let thread = Arc::new(StubCodexThread::new());
+                let models_manager = Arc::new(StubModelsManager);
+                let config = Config::load_with_cli_overrides_and_harness_overrides(
+                    vec![],
+                    ConfigOverrides::default(),
+                )
+                .await?;
+                let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+
+                let actor = ThreadActor::new(
+                    StubAuth,
+                    session_client,
+                    thread,
+                    models_manager,
+                    config,
+                    message_rx,
+                    resolution_tx,
+                    resolution_rx,
+                );
+
+                let mut plan_call_ids = std::collections::HashSet::new();
+
+                actor
+                    .replay_response_item(
+                        &ResponseItem::FunctionCall {
+                            id: None,
+                            call_id: "plan-call-id".to_string(),
+                            name: "update_plan".to_string(),
+                            arguments: serde_json::json!({
+                                "explanation": "testing replay",
+                                "plan": [
+                                    {
+                                        "step": "Read files",
+                                        "status": "in_progress"
+                                    },
+                                    {
+                                        "step": "Write summary",
+                                        "status": "pending"
+                                    }
+                                ]
+                            })
+                            .to_string(),
+                        },
+                        &mut plan_call_ids,
+                    )
+                    .await;
+
+                actor
+                    .replay_response_item(
+                        &ResponseItem::FunctionCallOutput {
+                            call_id: "plan-call-id".to_string(),
+                            output: FunctionCallOutputPayload::from_text("ok".to_string()),
+                        },
+                        &mut plan_call_ids,
+                    )
+                    .await;
+
+                let notifications = client.notifications.lock().unwrap();
+                assert_eq!(notifications.len(), 1, "{notifications:?}");
+                assert!(matches!(
+                    &notifications[0].update,
+                    SessionUpdate::Plan(plan)
+                        if plan.entries.len() == 2
+                            && plan.entries[0].content == "Read files"
+                            && plan.entries[0].status == PlanEntryStatus::InProgress
+                            && plan.entries[1].content == "Write summary"
+                            && plan.entries[1].status == PlanEntryStatus::Pending
+                ));
+                assert!(plan_call_ids.contains("plan-call-id"));
+
+                anyhow::Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test]
     async fn test_exec_approval_uses_available_decisions() -> anyhow::Result<()> {
         LocalSet::new()
             .run_until(async {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -3116,12 +3116,13 @@ impl<A: Auth> ThreadActor<A> {
         Some((title, locations, content))
     }
 
-    /// Parse shell function call arguments to extract command info for rich display.
+    /// Parse shell-like function call arguments to extract command info for rich display.
     /// Returns (title, kind, locations) if successful.
     ///
-    /// Handles both:
+    /// Handles:
     /// - `shell` / `container.exec`: `command` is `Vec<String>`
     /// - `shell_command`: `command` is a `String` (shell script)
+    /// - `exec_command`: `cmd` is a `String`
     fn parse_shell_function_call(
         &self,
         name: &str,
@@ -3140,6 +3141,18 @@ impl<A: Auth> ThreadActor<A> {
             // Wrap in bash -lc for parsing
             (
                 vec!["bash".to_string(), "-lc".to_string(), args.command],
+                args.workdir,
+            )
+        } else if name == "exec_command" {
+            #[derive(serde::Deserialize)]
+            struct ExecCommandArgs {
+                cmd: String,
+                #[serde(default)]
+                workdir: Option<String>,
+            }
+            let args: ExecCommandArgs = serde_json::from_str(arguments).ok()?;
+            (
+                vec!["bash".to_string(), "-lc".to_string(), args.cmd],
                 args.workdir,
             )
         } else {
@@ -3182,10 +3195,12 @@ impl<A: Auth> ThreadActor<A> {
                 call_id,
                 ..
             } => {
-                // Check if this is a shell command - parse it like we do for LocalShellCall
-                if matches!(name.as_str(), "shell" | "container.exec" | "shell_command")
-                    && let Some((title, kind, locations)) =
-                        self.parse_shell_function_call(name, arguments)
+                // Check if this is a shell-like command - parse it like we do for LocalShellCall
+                if matches!(
+                    name.as_str(),
+                    "shell" | "container.exec" | "shell_command" | "exec_command"
+                ) && let Some((title, kind, locations)) =
+                    self.parse_shell_function_call(name, arguments)
                 {
                     self.client
                         .send_tool_call(

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -3003,13 +3003,16 @@ impl<A: Auth> ThreadActor<A> {
     /// - `EventMsg` for user/agent messages and reasoning (like the TUI does)
     /// - `ResponseItem` for tool calls only (not persisted as EventMsg)
     async fn handle_replay_history(&mut self, history: Vec<RolloutItem>) -> Result<(), Error> {
+        let mut plan_call_ids = std::collections::HashSet::new();
+
         for item in history {
             match item {
                 RolloutItem::EventMsg(event_msg) => {
                     self.replay_event_msg(&event_msg).await;
                 }
                 RolloutItem::ResponseItem(response_item) => {
-                    self.replay_response_item(&response_item).await;
+                    self.replay_response_item(&response_item, &mut plan_call_ids)
+                        .await;
                 }
                 // Skip SessionMeta, TurnContext, Compacted
                 _ => {}
@@ -3185,7 +3188,11 @@ impl<A: Auth> ThreadActor<A> {
 
     /// Convert and send a single ResponseItem as ACP notification(s) during replay.
     /// Only handles tool calls - messages/reasoning are handled via EventMsg.
-    async fn replay_response_item(&self, item: &ResponseItem) {
+    async fn replay_response_item(
+        &self,
+        item: &ResponseItem,
+        plan_call_ids: &mut std::collections::HashSet<String>,
+    ) {
         match item {
             // Skip Message and Reasoning - these are handled via EventMsg
             ResponseItem::Message { .. } | ResponseItem::Reasoning { .. } => {}
@@ -3195,6 +3202,18 @@ impl<A: Auth> ThreadActor<A> {
                 call_id,
                 ..
             } => {
+                if name == "update_plan" {
+                    if let Ok(UpdatePlanArgs {
+                        explanation: _,
+                        plan,
+                    }) = serde_json::from_str::<UpdatePlanArgs>(arguments)
+                    {
+                        self.client.update_plan(plan).await;
+                        plan_call_ids.insert(call_id.clone());
+                        return;
+                    }
+                }
+
                 // Check if this is a shell-like command - parse it like we do for LocalShellCall
                 if matches!(
                     name.as_str(),
@@ -3227,6 +3246,10 @@ impl<A: Auth> ThreadActor<A> {
                     .await;
             }
             ResponseItem::FunctionCallOutput { call_id, output } => {
+                if plan_call_ids.contains(call_id) {
+                    return;
+                }
+
                 self.client
                     .send_tool_call_completed(call_id.clone(), serde_json::to_value(output).ok())
                     .await;
@@ -3484,6 +3507,7 @@ mod tests {
     use agent_client_protocol::{RequestPermissionResponse, TextContent};
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
     use codex_protocol::config_types::ModeKind;
+    use codex_protocol::models::FunctionCallOutputPayload;
     use tokio::{
         sync::{Mutex, Notify, mpsc::UnboundedSender},
         task::LocalSet,
@@ -4526,17 +4550,22 @@ mod tests {
                     resolution_rx,
                 );
 
+                let mut plan_call_ids = std::collections::HashSet::new();
+
                 actor
-                    .replay_response_item(&ResponseItem::FunctionCall {
-                        id: None,
-                        call_id: "call-id".to_string(),
-                        name: "exec_command".to_string(),
-                        arguments: serde_json::json!({
-                            "cmd": "cat README.md",
-                            "workdir": "/tmp/project"
-                        })
-                        .to_string(),
-                    })
+                    .replay_response_item(
+                        &ResponseItem::FunctionCall {
+                            id: None,
+                            call_id: "call-id".to_string(),
+                            name: "exec_command".to_string(),
+                            arguments: serde_json::json!({
+                                "cmd": "cat README.md",
+                                "workdir": "/tmp/project"
+                            })
+                            .to_string(),
+                        },
+                        &mut plan_call_ids,
+                    )
                     .await;
 
                 let notifications = client.notifications.lock().unwrap();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4498,6 +4498,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_replay_exec_command_function_call_is_structured() -> anyhow::Result<()> {
+        LocalSet::new()
+            .run_until(async {
+                let session_id = SessionId::new("test");
+                let client = Arc::new(StubClient::new());
+                let session_client =
+                    SessionClient::with_client(session_id, client.clone(), Arc::default());
+                let thread = Arc::new(StubCodexThread::new());
+                let models_manager = Arc::new(StubModelsManager);
+                let config = Config::load_with_cli_overrides_and_harness_overrides(
+                    vec![],
+                    ConfigOverrides::default(),
+                )
+                .await?;
+                let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+
+                let actor = ThreadActor::new(
+                    StubAuth,
+                    session_client,
+                    thread,
+                    models_manager,
+                    config,
+                    message_rx,
+                    resolution_tx,
+                    resolution_rx,
+                );
+
+                actor
+                    .replay_response_item(&ResponseItem::FunctionCall {
+                        id: None,
+                        call_id: "call-id".to_string(),
+                        name: "exec_command".to_string(),
+                        arguments: serde_json::json!({
+                            "cmd": "cat README.md",
+                            "workdir": "/tmp/project"
+                        })
+                        .to_string(),
+                    })
+                    .await;
+
+                let notifications = client.notifications.lock().unwrap();
+                assert_eq!(notifications.len(), 1, "{notifications:?}");
+                assert!(matches!(
+                    &notifications[0].update,
+                    SessionUpdate::ToolCall(tool_call)
+                        if tool_call.title == "Read README.md"
+                            && tool_call.kind == ToolKind::Read
+                            && tool_call.status == ToolCallStatus::Completed
+                            && tool_call.raw_input.is_some()
+                ));
+
+                anyhow::Ok(())
+            })
+            .await
+    }
+
+    #[tokio::test]
     async fn test_exec_approval_uses_available_decisions() -> anyhow::Result<()> {
         LocalSet::new()
             .run_until(async {


### PR DESCRIPTION
## Context

I was using Codex ACP in Zed for various ongoing tasks. I was able to reenter threads of previous sessions or previous projects and seeing structured output for CLI commands and the plan drafted during these threads.

After a thread where a prompt messed with some dirty inputs (cross-referencing local files/previous threads), the Codex CLI panel's rendering degraded and all CLI commands/plans rendered as generic `exec_command` and `update_plan`, which made the reading of threads difficult.

I cloned this repo and worked locally and solved this rendering issue in my fork, which allows me to continue to work on my projects without downgrading my UX.

## Summary

This PR fixes two history replay parity issues in `codex-acp`:

- replayed `FunctionCall(name="exec_command")` entries were shown as generic `exec_command` tool calls instead of meaningful command titles such as `Read ...`, `Search ...`, or `List ...`
- replayed `FunctionCall(name="update_plan")` entries were shown as generic tool calls instead of restoring the ACP plan UI

Live rendering already handled both cases better; the replay path did not.

## Problem

When sessions were restored from history, replay did not fully reconstruct the richer ACP presentation used during live execution.

In practice this caused two visible regressions in old threads:

1. shell-backed commands stored as `FunctionCall(name="exec_command")` were replayed as generic tool calls
2. plan updates stored as `FunctionCall(name="update_plan")` were replayed as generic tool calls instead of plan updates

This made restored history less useful and less consistent with live session behavior.

## Root cause

The replay path in `thread.rs` handled only a subset of historical tool-call shapes as structured replay events.

### `exec_command`

Replay already special-cased a few shell-like function names:

- `shell`
- `container.exec`
- `shell_command`

But historical `FunctionCall(name="exec_command")` fell through to the generic fallback path, so replay lost semantic tool metadata.

### `update_plan`

Live plan updates already had a dedicated path:

- `PlanUpdate` events were translated into `SessionUpdate::Plan`

But during replay, historical `FunctionCall(name="update_plan")` entries were not translated back into plan updates and instead fell through to the generic function-call fallback.

## What changed

### `exec_command`

Replay now treats `exec_command` as a shell-like function call.

It parses:

- `cmd`
- `workdir`

and reuses the existing command parsing logic to recover structured tool-call metadata during replay.

If parsing fails, replay still falls back to the previous generic behavior.

### `update_plan`

Replay now special-cases `FunctionCall(name="update_plan")`.

It:

- parses the stored plan arguments
- emits `SessionUpdate::Plan`
- tracks the corresponding `call_id` only during the current replay pass
- suppresses the matching `FunctionCallOutput` during that same replay pass so replay does not emit a stray generic tool update afterward

This replay bookkeeping is local to the replay pass and does not become persistent session state.

## Result

After rebuilding and reopening older threads in Zed:

- replayed shell-backed tool calls render with meaningful titles again
- replayed plan updates render as proper plan UI again

Examples observed after the fix include:

- `Read Foo.scala`
- `Read Bar.scala`
- `Read Baz.scala`
- `List /Users/irony/Developer/some-project/src/some-module`

All these commands were previously shown as `exec_command`.

## Scope

This PR only changes history replay behavior.

It does not change:

- live tool-call rendering
- live plan update handling
- stored rollout / session history data
- authentication, session lifecycle, or prompt submission behavior

## Risk

- the changes are limited to replay
- existing generic fallback behavior remains in place for unrecognized or unparsable function calls
- no historical data is rewritten
- the additional replay bookkeeping for `update_plan` is local to a single replay pass

## Testing

### Automated

- Ran `cargo test`

Added 2 tests:

- replaying `FunctionCall(name="exec_command")` produces a structured tool call instead of a generic one:

    `cargo test test_replay_exec_command_function_call_is_structured`

- replaying `FunctionCall(name="update_plan")` produces a plan update and suppresses the matching generic function-call output:

    `cargo test test_replay_update_plan_function_call_emits_plan_update`

-   Ran `cargo fmt --check`

### Manual

- Build an artefact with `cargo build --release`
- Add a custom agent in Zed
- Opened older threads in Zed containing replayed `exec_command` calls
- Opened older threads in Zed containing replayed `update_plan` entries
- See the difference between this custom agent and Codex CLI

Observed that:

- command history now renders with meaningful titles
- plan history now renders as plan UI

## Issue relevance

This branch addresses the following replay downgrade problems:

- generic replay of historical `exec_command`
- generic replay of historical `update_plan`

It does not solve every rendering anomaly found during investigation, especially related to unusual embedded transcript/context content.

I used Codex to help me investigate the issue, drafted the code and the PR.