### PR TITLE
Fix missing residency header on API requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,12 @@ pub async fn run_main(
                 )
             })?;
 
+    // Apply residency requirement so the HTTP client sends the
+    // x-openai-internal-codex-residency header on all requests.
+    codex_core::default_client::set_default_client_residency_requirement(
+        config.enforce_residency.value(),
+    );
+
     // Create our Agent implementation with notification channel
     let agent = Rc::new(codex_agent::CodexAgent::new(config));
 


### PR DESCRIPTION
The codex-acp adapter never calls `set_default_client_residency_requirement()`, so the `x-openai-internal-codex-residency` HTTP header is never sent on API requests. This breaks **managed workspaces** that require the header for region authorization.

**Symptom:** 401 "Workspace is not authorized in this region" on the WebSocket connection to `chatgpt.com/backend-api/codex/responses`.

## Fix

One-line addition mirroring what `codex-rs/exec/src/lib.rs` and `codex-rs/tui/src/lib.rs` already do: call `set_default_client_residency_requirement(config.enforce_residency.value())` after config is loaded, before the first API request.

---

This fix was identified and verified with AI assistance (Claude Code), with me guiding the investigation, reviewing all changes, and testing end-to-end.