### PR TITLE
fix: add JetBrains ACP auth compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,52 @@ To use Codex, open the Agent Panel and click "New Codex Thread" from the `+` but
 
 Read the docs on [External Agent](https://zed.dev/docs/ai/external-agents) support.
 
+### JetBrains IDEs
+
+JetBrains IDEs expose ACP agents through the JetBrains AI Assistant agent registry. That registry is separate from Zed's registry, so Codex may not appear in the built-in JetBrains agent list even though this adapter is available in Zed.
+
+Add Codex manually by creating or updating `~/.jetbrains/acp.json`:
+
+```json
+{
+  "default_mcp_settings": {
+    "use_custom_mcp": true,
+    "use_idea_mcp": true
+  },
+  "agent_servers": {
+    "Codex": {
+      "command": "npx",
+      "args": ["-y", "@zed-industries/codex-acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+If you installed a release binary instead of using npm, set `command` to the absolute path of the `codex-acp` binary and remove `args`.
+
+Some JetBrains AI Assistant builds still expect the older ACP `env_var.varName` auth field and may fail to initialize when the agent advertises API-key auth methods. If you already authenticate Codex through the regular Codex CLI or have a `CODEX_HOME` with valid credentials, you can hide those env-var auth methods for JetBrains:
+
+```json
+{
+  "default_mcp_settings": {
+    "use_custom_mcp": true,
+    "use_idea_mcp": true
+  },
+  "agent_servers": {
+    "Codex": {
+      "command": "npx",
+      "args": ["-y", "@zed-industries/codex-acp"],
+      "env": {
+        "CODEX_ACP_DISABLE_ENV_AUTH_METHODS": "1"
+      }
+    }
+  }
+}
+```
+
+Restart the IDE or start a new AI Assistant chat after changing `~/.jetbrains/acp.json`.
+
 ### Other clients
 
 Or try it with any of the other [ACP compatible clients](https://agentclientprotocol.com/overview/clients)!

--- a/npm/README.md
+++ b/npm/README.md
@@ -36,6 +36,52 @@ To use Codex, open the Agent Panel and click "New Codex Thread" from the `+` but
 
 Read the docs on [External Agent](https://zed.dev/docs/ai/external-agents) support.
 
+### JetBrains IDEs
+
+JetBrains IDEs expose ACP agents through the JetBrains AI Assistant agent registry. That registry is separate from Zed's registry, so Codex may not appear in the built-in JetBrains agent list even though this adapter is available in Zed.
+
+Add Codex manually by creating or updating `~/.jetbrains/acp.json`:
+
+```json
+{
+  "default_mcp_settings": {
+    "use_custom_mcp": true,
+    "use_idea_mcp": true
+  },
+  "agent_servers": {
+    "Codex": {
+      "command": "npx",
+      "args": ["-y", "@zed-industries/codex-acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+If you installed a release binary instead of using npm, set `command` to the absolute path of the `codex-acp` binary and remove `args`.
+
+Some JetBrains AI Assistant builds still expect the older ACP `env_var.varName` auth field and may fail to initialize when the agent advertises API-key auth methods. If you already authenticate Codex through the regular Codex CLI or have a `CODEX_HOME` with valid credentials, you can hide those env-var auth methods for JetBrains:
+
+```json
+{
+  "default_mcp_settings": {
+    "use_custom_mcp": true,
+    "use_idea_mcp": true
+  },
+  "agent_servers": {
+    "Codex": {
+      "command": "npx",
+      "args": ["-y", "@zed-industries/codex-acp"],
+      "env": {
+        "CODEX_ACP_DISABLE_ENV_AUTH_METHODS": "1"
+      }
+    }
+  }
+}
+```
+
+Restart the IDE or start a new AI Assistant chat after changing `~/.jetbrains/acp.json`.
+
 ### Other clients
 
 [Submit a PR](https://github.com/zed-industries/codex-acp/pulls) to add yours!

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -432,9 +432,16 @@ impl CodexAgent {
             CodexAuthMethod::CodexApiKey.into(),
             CodexAuthMethod::OpenAiApiKey.into(),
         ];
+        if std::env::var("CODEX_ACP_DISABLE_ENV_AUTH_METHODS").is_ok() {
+            auth_methods.retain(|method| {
+                matches!(method, AuthMethod::Agent(AuthMethodAgent { id, .. }) if id.0.as_ref() == "chatgpt")
+            });
+        }
         // Until codex device code auth works, we can't use this in remote ssh projects
         if std::env::var("NO_BROWSER").is_ok() {
-            auth_methods.remove(0);
+            auth_methods.retain(|method| {
+                !matches!(method, AuthMethod::Agent(AuthMethodAgent { id, .. }) if id.0.as_ref() == "chatgpt")
+            });
         }
 
         Ok(InitializeResponse::new(protocol_version)


### PR DESCRIPTION
Avoid advertising env-var auth methods when CODEX_ACP_DISABLE_ENV_AUTH_METHODS is set, which lets JetBrains ACP clients that still expect the legacy env_var.varName shape initialize successfully. Also document manual JetBrains setup through ~/.jetbrains/acp.json because JetBrains uses a separate ACP registry from Zed.

**Changes:**
- Add CODEX_ACP_DISABLE_ENV_AUTH_METHODS to hide env-var auth methods for incompatible ACP clients
- Preserve ChatGPT auth and avoid index-based auth method removal for NO_BROWSER
- Document JetBrains IDE setup and the compatibility flag in both READMEs

Closes zed-industries/codex-acp#230

Related: zed-industries/codex-acp#207