### PR TITLE
Support Codex ACP thread renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "codex-models-manager",
  "codex-protocol",
  "codex-shell-command",
+ "codex-thread-store",
  "codex-utils-approval-presets",
  "codex-utils-cli",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0
 codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
 codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
 codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
 codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
 codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
 diffy = { version = "0.5.0", features = ["std"] }

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -15,8 +15,8 @@ use agent_client_protocol as acp;
 use codex_config::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
     NewThread, RolloutRecorder, SortDirection, StateDbHandle, ThreadManager, ThreadSortKey,
-    config::Config, find_thread_path_by_id_str, init_state_db, parse_cursor,
-    resolve_installation_id, thread_store_from_config,
+    config::Config, find_thread_names_by_ids, find_thread_path_by_id_str, init_state_db,
+    parse_cursor, resolve_installation_id, thread_store_from_config,
 };
 use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_login::{
@@ -28,11 +28,11 @@ use codex_protocol::{
     protocol::{InitialHistory, SessionSource},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::thread::Thread;
@@ -566,11 +566,13 @@ impl CodexAgent {
             .lock()
             .unwrap()
             .insert(session_id.clone(), config.cwd.to_path_buf());
+        let thread_store = thread_store_from_config(&config, self.state_db.clone());
         let thread = Arc::new(Thread::new(
             session_id.clone(),
             thread,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
+            thread_store,
             self.client_capabilities.clone(),
             config.clone(),
             cx,
@@ -640,11 +642,13 @@ impl CodexAgent {
         .await
         .map_err(|e| Error::internal_error().data(e.to_string()))?;
 
+        let thread_store = thread_store_from_config(&config, self.state_db.clone());
         let thread = Arc::new(Thread::new(
             session_id.clone(),
             thread,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
+            thread_store,
             self.client_capabilities.clone(),
             config.clone(),
             cx,
@@ -695,7 +699,7 @@ impl CodexAgent {
         .await
         .map_err(|err| Error::internal_error().data(format!("failed to list sessions: {err}")))?;
 
-        let sessions = page
+        let session_items = page
             .items
             .into_iter()
             .filter_map(|item| {
@@ -708,17 +712,36 @@ impl CodexAgent {
                     return None;
                 }
 
-                let title = item
-                    .first_user_message
-                    .as_deref()
-                    .and_then(format_session_title);
                 let updated_at = item.updated_at.or(item.created_at);
 
-                Some(
-                    SessionInfo::new(SessionId::new(thread_id.to_string()), item_cwd)
-                        .title(title)
-                        .updated_at(updated_at),
-                )
+                Some((thread_id, item_cwd, item.first_user_message, updated_at))
+            })
+            .collect::<Vec<_>>();
+
+        let thread_ids = session_items
+            .iter()
+            .map(|(thread_id, _, _, _)| *thread_id)
+            .collect::<HashSet<_>>();
+        let thread_names =
+            match find_thread_names_by_ids(&self.config.codex_home, &thread_ids).await {
+                Ok(thread_names) => thread_names,
+                Err(err) => {
+                    warn!("failed to read Codex thread names: {err}");
+                    HashMap::new()
+                }
+            };
+
+        let sessions = session_items
+            .into_iter()
+            .map(|(thread_id, item_cwd, first_user_message, updated_at)| {
+                let title = thread_names
+                    .get(&thread_id)
+                    .cloned()
+                    .or_else(|| first_user_message.as_deref().and_then(format_session_title));
+
+                SessionInfo::new(SessionId::new(thread_id.to_string()), item_cwd)
+                    .title(title)
+                    .updated_at(updated_at)
             })
             .collect::<Vec<_>>();
 

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -15,7 +15,7 @@ use agent_client_protocol as acp;
 use codex_config::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
     NewThread, RolloutRecorder, SortDirection, ThreadManager, ThreadSortKey, config::Config,
-    find_thread_path_by_id_str, parse_cursor,
+    find_thread_names_by_ids, find_thread_path_by_id_str, parse_cursor,
 };
 use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_login::{
@@ -28,11 +28,11 @@ use codex_protocol::{
     protocol::{InitialHistory, SessionSource},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::thread::Thread;
@@ -674,7 +674,7 @@ impl CodexAgent {
         .await
         .map_err(|err| Error::internal_error().data(format!("failed to list sessions: {err}")))?;
 
-        let sessions = page
+        let session_items = page
             .items
             .into_iter()
             .filter_map(|item| {
@@ -687,17 +687,36 @@ impl CodexAgent {
                     return None;
                 }
 
-                let title = item
-                    .first_user_message
-                    .as_deref()
-                    .and_then(format_session_title);
                 let updated_at = item.updated_at.or(item.created_at);
 
-                Some(
-                    SessionInfo::new(SessionId::new(thread_id.to_string()), item_cwd)
-                        .title(title)
-                        .updated_at(updated_at),
-                )
+                Some((thread_id, item_cwd, item.first_user_message, updated_at))
+            })
+            .collect::<Vec<_>>();
+
+        let thread_ids = session_items
+            .iter()
+            .map(|(thread_id, _, _, _)| *thread_id)
+            .collect::<HashSet<_>>();
+        let thread_names =
+            match find_thread_names_by_ids(&self.config.codex_home, &thread_ids).await {
+                Ok(thread_names) => thread_names,
+                Err(err) => {
+                    warn!("failed to read Codex thread names: {err}");
+                    HashMap::new()
+                }
+            };
+
+        let sessions = session_items
+            .into_iter()
+            .map(|(thread_id, item_cwd, first_user_message, updated_at)| {
+                let title = thread_names
+                    .get(&thread_id)
+                    .cloned()
+                    .or_else(|| first_user_message.as_deref().and_then(format_session_title));
+
+                SessionInfo::new(SessionId::new(thread_id.to_string()), item_cwd)
+                    .title(title)
+                    .updated_at(updated_at)
             })
             .collect::<Vec<_>>();
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -17,11 +17,11 @@ use agent_client_protocol::{
         PlanEntryStatus, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
         RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome, SessionConfigId,
         SessionConfigOption, SessionConfigOptionCategory, SessionConfigOptionValue,
-        SessionConfigSelectOption, SessionConfigValueId, SessionId, SessionMode, SessionModeId,
-        SessionModeState, SessionModelState, SessionNotification, SessionUpdate, StopReason,
-        Terminal, TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId,
-        ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
-        UnstructuredCommandInput, UsageUpdate,
+        SessionConfigSelectOption, SessionConfigValueId, SessionId, SessionInfoUpdate, SessionMode,
+        SessionModeId, SessionModeState, SessionModelState, SessionNotification, SessionUpdate,
+        StopReason, Terminal, TextContent, TextResourceContents, ToolCall, ToolCallContent,
+        ToolCallId, ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        ToolKind, UnstructuredCommandInput, UsageUpdate,
     },
 };
 use codex_apply_patch::parse_patch;
@@ -30,10 +30,12 @@ use codex_core::{
     config::{Config, set_project_trust_level},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
+    util::normalize_thread_name,
 };
 use codex_login::auth::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::{
+    ThreadId,
     approvals::{
         ElicitationRequest, ElicitationRequestEvent, GuardianAssessmentAction,
         GuardianCommandSource,
@@ -76,6 +78,7 @@ use codex_protocol::{
     user_input::UserInput,
 };
 use codex_shell_command::parse_command::parse_command;
+use codex_thread_store::{ThreadMetadataPatch, ThreadStore, UpdateThreadMetadataParams};
 use codex_utils_approval_presets::{ApprovalPreset, builtin_approval_presets};
 use heck::ToTitleCase;
 use itertools::Itertools;
@@ -255,6 +258,47 @@ impl ModelsManagerImpl for Arc<dyn ModelsManager> {
     }
 }
 
+trait ThreadNameStore: Send + Sync {
+    fn update_thread_name(
+        &self,
+        thread_id: ThreadId,
+        name: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>>;
+}
+
+struct ThreadStoreNameUpdater {
+    thread_store: Arc<dyn ThreadStore>,
+}
+
+impl ThreadStoreNameUpdater {
+    fn new(thread_store: Arc<dyn ThreadStore>) -> Self {
+        Self { thread_store }
+    }
+}
+
+impl ThreadNameStore for ThreadStoreNameUpdater {
+    fn update_thread_name(
+        &self,
+        thread_id: ThreadId,
+        name: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+        Box::pin(async move {
+            self.thread_store
+                .update_thread_metadata(UpdateThreadMetadataParams {
+                    thread_id,
+                    patch: ThreadMetadataPatch {
+                        name: Some(name),
+                        ..Default::default()
+                    },
+                    include_archived: false,
+                })
+                .await
+                .map_err(|err| Error::internal_error().data(err.to_string()))?;
+            Ok(())
+        })
+    }
+}
+
 pub trait Auth {
     fn logout(&self) -> impl Future<Output = Result<bool, Error>> + Send;
 }
@@ -324,6 +368,7 @@ impl Thread {
         thread: Arc<dyn CodexThreadImpl>,
         auth: Arc<AuthManager>,
         models_manager: Arc<dyn ModelsManagerImpl>,
+        thread_store: Arc<dyn ThreadStore>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
         config: Config,
         cx: ConnectionTo<Client>,
@@ -336,6 +381,7 @@ impl Thread {
             SessionClient::new(session_id, cx, client_capabilities),
             thread.clone(),
             models_manager,
+            Arc::new(ThreadStoreNameUpdater::new(thread_store)),
             config,
             message_rx,
             resolution_tx,
@@ -2741,6 +2787,8 @@ struct ThreadActor<A> {
     config: Config,
     /// The models available for this thread.
     models_manager: Arc<dyn ModelsManagerImpl>,
+    /// Storage surface used for thread metadata updates.
+    thread_name_store: Arc<dyn ThreadNameStore>,
     /// Internal message sender used to route spawned interaction results back to the actor.
     resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
     /// A sender for each interested `Op` submission that needs events routed.
@@ -2760,6 +2808,7 @@ impl<A: Auth> ThreadActor<A> {
         client: SessionClient,
         thread: Arc<dyn CodexThreadImpl>,
         models_manager: Arc<dyn ModelsManagerImpl>,
+        thread_name_store: Arc<dyn ThreadNameStore>,
         config: Config,
         message_rx: mpsc::UnboundedReceiver<ThreadMessage>,
         resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
@@ -2771,6 +2820,7 @@ impl<A: Auth> ThreadActor<A> {
             thread,
             config,
             models_manager,
+            thread_name_store,
             resolution_tx,
             submissions: HashMap::new(),
             message_rx,
@@ -2919,6 +2969,9 @@ impl<A: Auth> ThreadActor<A> {
             AvailableCommand::new(
                 "compact",
                 "summarize conversation to prevent hitting the context limit",
+            ),
+            AvailableCommand::new("rename", "rename the current thread").input(
+                AvailableCommandInput::Unstructured(UnstructuredCommandInput::new("new name")),
             ),
             AvailableCommand::new("logout", "logout of Codex"),
         ]
@@ -3307,6 +3360,12 @@ impl<A: Auth> ThreadActor<A> {
                     self.auth.logout().await?;
                     return Err(Error::auth_required());
                 }
+                "rename" if !rest.is_empty() => {
+                    let name = normalize_thread_name(rest).ok_or_else(Error::invalid_params)?;
+                    self.handle_rename(name).await?;
+                    drop(response_tx.send(Ok(StopReason::EndTurn)));
+                    return Ok(response_rx);
+                }
                 _ => {
                     op = Op::UserInput {
                         items,
@@ -3344,6 +3403,18 @@ impl<A: Auth> ThreadActor<A> {
         self.submissions.insert(submission_id, state);
 
         Ok(response_rx)
+    }
+
+    async fn handle_rename(&mut self, name: String) -> Result<(), Error> {
+        let thread_id = ThreadId::from_string(self.client.session_id.0.as_ref())
+            .map_err(|err| Error::internal_error().data(err.to_string()))?;
+        self.thread_name_store
+            .update_thread_name(thread_id, name.clone())
+            .await?;
+        send_session_title_update(&self.client, Some(name.clone()));
+        self.client
+            .send_agent_text(format!("Thread renamed to: {name}\n"));
+        Ok(())
     }
 
     async fn handle_set_mode(&mut self, mode: SessionModeId) -> Result<(), Error> {
@@ -3505,6 +3576,9 @@ impl<A: Auth> ThreadActor<A> {
             }
             EventMsg::AgentReasoningRawContent(AgentReasoningRawContentEvent { text }) => {
                 self.client.send_agent_thought(text.clone());
+            }
+            EventMsg::SessionConfigured(event) => {
+                send_session_title_update(&self.client, event.thread_name.clone());
             }
             EventMsg::ThreadGoalUpdated(event) => {
                 self.client
@@ -3803,9 +3877,19 @@ impl<A: Auth> ThreadActor<A> {
     async fn handle_event(&mut self, Event { id, msg }: Event) {
         if let Some(submission) = self.submissions.get_mut(&id) {
             submission.handle_event(&self.client, msg).await;
+        } else if let EventMsg::SessionConfigured(event) = msg {
+            send_session_title_update(&self.client, event.thread_name);
         } else {
             warn!("Received event for unknown submission ID: {id} {msg:?}");
         }
+    }
+}
+
+fn send_session_title_update(client: &SessionClient, title: Option<String>) {
+    if let Some(title) = title {
+        client.send_notification(SessionUpdate::SessionInfoUpdate(
+            SessionInfoUpdate::new().title(title),
+        ));
     }
 }
 
@@ -4255,6 +4339,42 @@ mod tests {
                 ..
             }) if text == "Hi"
         ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rename_sends_title_update() -> anyhow::Result<()> {
+        let (session_id, client, thread, message_tx, _handle) = setup().await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["/rename My New Thread".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let stop_reason = prompt_response_rx.await??.await??;
+        assert_eq!(stop_reason, StopReason::EndTurn);
+        drop(message_tx);
+
+        assert!(thread.ops.lock().unwrap().is_empty());
+        let notifications = client.notifications.lock().unwrap();
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::SessionInfoUpdate(update)
+                    if update.title.value() == Some(&"My New Thread".to_string())
+            )
+        }));
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text == "Thread renamed to: My New Thread\n"
+            )
+        }));
 
         Ok(())
     }
@@ -4755,7 +4875,7 @@ mod tests {
         UnboundedSender<ThreadMessage>,
         tokio::task::JoinHandle<()>,
     )> {
-        let session_id = SessionId::new("test");
+        let session_id = SessionId::new(ThreadId::new().to_string());
         let client = Arc::new(StubClient::new());
         let session_client =
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
@@ -4774,6 +4894,7 @@ mod tests {
             session_client,
             conversation.clone(),
             models_manager,
+            Arc::new(StubThreadNameStore::default()),
             config,
             message_rx,
             resolution_tx,
@@ -4789,6 +4910,24 @@ mod tests {
     impl Auth for StubAuth {
         async fn logout(&self) -> Result<bool, Error> {
             Ok(true)
+        }
+    }
+
+    #[derive(Default)]
+    struct StubThreadNameStore {
+        updates: std::sync::Mutex<Vec<(ThreadId, String)>>,
+    }
+
+    impl ThreadNameStore for StubThreadNameStore {
+        fn update_thread_name(
+            &self,
+            thread_id: ThreadId,
+            name: String,
+        ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>> {
+            Box::pin(async move {
+                self.updates.lock().unwrap().push((thread_id, name));
+                Ok(())
+            })
         }
     }
 
@@ -5646,6 +5785,7 @@ mod tests {
             session_client,
             conversation.clone(),
             models_manager,
+            Arc::new(StubThreadNameStore::default()),
             config,
             message_rx,
             resolution_tx,

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -30,6 +30,7 @@ use codex_core::{
     config::{Config, set_project_trust_level},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
+    util::normalize_thread_name,
 };
 use codex_login::auth::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
@@ -77,7 +78,7 @@ use heck::ToTitleCase;
 use itertools::Itertools;
 use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 /// Abstraction over the ACP connection for sending notifications and requests
@@ -678,18 +679,21 @@ fn format_mcp_tool_approval_value(value: &serde_json::Value) -> String {
 enum SubmissionState {
     /// User prompts, including slash commands like /init, /review, /compact, /undo.
     Prompt(PromptState),
+    Rename(RenameState),
 }
 
 impl SubmissionState {
     fn is_active(&self) -> bool {
         match self {
             Self::Prompt(state) => state.is_active(),
+            Self::Rename(state) => state.is_active(),
         }
     }
 
     async fn handle_event(&mut self, client: &SessionClient, event: EventMsg) {
         match self {
             Self::Prompt(state) => state.handle_event(client, event).await,
+            Self::Rename(state) => state.handle_event(client, event),
         }
     }
 
@@ -705,6 +709,10 @@ impl SubmissionState {
                     .handle_permission_request_resolved(client, request_key, response)
                     .await
             }
+            Self::Rename(_) => {
+                warn!("Ignoring permission response for rename submission");
+                Ok(())
+            }
         }
     }
 
@@ -713,14 +721,18 @@ impl SubmissionState {
             Self::Prompt(state) => {
                 state.abort_pending_interactions();
             }
+            Self::Rename(_) => {}
         }
     }
 
     fn fail(&mut self, err: Error) {
-        if let Self::Prompt(state) = self
-            && let Some(response_tx) = state.response_tx.take()
-        {
-            drop(response_tx.send(Err(err)));
+        match self {
+            Self::Prompt(state) => {
+                if let Some(response_tx) = state.response_tx.take() {
+                    drop(response_tx.send(Err(err)));
+                }
+            }
+            Self::Rename(state) => state.fail(err),
         }
     }
 }
@@ -744,6 +756,71 @@ struct PromptState {
     response_tx: Option<oneshot::Sender<Result<StopReason, Error>>>,
     seen_message_deltas: bool,
     seen_reasoning_deltas: bool,
+}
+
+struct RenameState {
+    response_tx: Option<oneshot::Sender<Result<StopReason, Error>>>,
+}
+
+impl RenameState {
+    fn new(response_tx: oneshot::Sender<Result<StopReason, Error>>) -> Self {
+        Self {
+            response_tx: Some(response_tx),
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.response_tx
+            .as_ref()
+            .is_some_and(|response_tx| !response_tx.is_closed())
+    }
+
+    fn fail(&mut self, err: Error) {
+        if let Some(response_tx) = self.response_tx.take() {
+            drop(response_tx.send(Err(err)));
+        }
+    }
+
+    fn handle_event(&mut self, client: &SessionClient, event: EventMsg) {
+        match event {
+            EventMsg::ThreadNameUpdated(event) => {
+                if let Some(title) = event.thread_name {
+                    send_session_title_update(client, Some(title.clone()));
+                    client.send_agent_text(format!("Thread renamed to: {title}\n"));
+                    if let Some(response_tx) = self.response_tx.take() {
+                        drop(response_tx.send(Ok(StopReason::EndTurn)));
+                    }
+                }
+            }
+            EventMsg::Error(ErrorEvent {
+                message,
+                codex_error_info,
+            }) => {
+                if let Some(response_tx) = self.response_tx.take() {
+                    drop(response_tx.send(Err(Error::internal_error().data(
+                        json!({ "message": message, "codex_error_info": codex_error_info }),
+                    ))));
+                }
+            }
+            EventMsg::StreamError(StreamErrorEvent {
+                message,
+                codex_error_info,
+                additional_details,
+            }) => {
+                error!(
+                    "Rename failed during stream: {message} {codex_error_info:?} {additional_details:?}"
+                );
+                if let Some(response_tx) = self.response_tx.take() {
+                    drop(response_tx.send(Err(Error::internal_error().data(
+                        json!({ "message": message, "codex_error_info": codex_error_info }),
+                    ))));
+                }
+            }
+            event => {
+                debug!("Ignoring event for rename submission: {event:?}");
+            }
+        }
+    }
 }
 
 impl PromptState {
@@ -1063,11 +1140,11 @@ impl PromptState {
             }
             EventMsg::ThreadNameUpdated(event) => {
                 info!("Thread name updated: {:?}", event.thread_name);
-                if let Some(title) = event.thread_name {
-                    client.send_notification(SessionUpdate::SessionInfoUpdate(
-                        SessionInfoUpdate::new().title(title),
-                    ));
-                }
+                send_session_title_update(client, event.thread_name);
+            }
+            EventMsg::SessionConfigured(event) => {
+                info!("Session configured with thread name: {:?}", event.thread_name);
+                send_session_title_update(client, event.thread_name);
             }
             EventMsg::PlanUpdate(UpdatePlanArgs { explanation, plan }) => {
                 // Send this to the client via session/update notification
@@ -1357,7 +1434,6 @@ impl PromptState {
             | EventMsg::AgentReasoningDelta(..)
             | EventMsg::AgentReasoningRawContentDelta(..)
             | EventMsg::RawResponseItem(..)
-            | EventMsg::SessionConfigured(..)
             // TODO: Subagent UI?
             | EventMsg::CollabAgentSpawnBegin(..)
             | EventMsg::CollabAgentSpawnEnd(..)
@@ -2761,6 +2837,9 @@ impl<A: Auth> ThreadActor<A> {
                 "compact",
                 "summarize conversation to prevent hitting the context limit",
             ),
+            AvailableCommand::new("rename", "rename the current thread").input(
+                AvailableCommandInput::Unstructured(UnstructuredCommandInput::new("new name")),
+            ),
             AvailableCommand::new("undo", "undo Codex’s most recent turn"),
             AvailableCommand::new("logout", "logout of Codex"),
         ]
@@ -3173,6 +3252,19 @@ impl<A: Auth> ThreadActor<A> {
                     self.auth.logout()?;
                     return Err(Error::auth_required());
                 }
+                "rename" if !rest.is_empty() => {
+                    let name = normalize_thread_name(rest).ok_or_else(Error::invalid_params)?;
+                    let submission_id = self
+                        .thread
+                        .submit(Op::SetThreadName { name })
+                        .await
+                        .map_err(|e| Error::internal_error().data(e.to_string()))?;
+                    self.submissions.insert(
+                        submission_id,
+                        SubmissionState::Rename(RenameState::new(response_tx)),
+                    );
+                    return Ok(response_rx);
+                }
                 _ => {
                     op = Op::UserInput {
                         items,
@@ -3375,6 +3467,12 @@ impl<A: Auth> ThreadActor<A> {
             }
             EventMsg::AgentReasoningRawContent(AgentReasoningRawContentEvent { text }) => {
                 self.client.send_agent_thought(text.clone());
+            }
+            EventMsg::SessionConfigured(event) => {
+                send_session_title_update(&self.client, event.thread_name.clone());
+            }
+            EventMsg::ThreadNameUpdated(event) => {
+                send_session_title_update(&self.client, event.thread_name.clone());
             }
             // Skip other event types during replay - they either:
             // - Are transient (deltas, turn lifecycle)
@@ -3647,9 +3745,30 @@ impl<A: Auth> ThreadActor<A> {
     async fn handle_event(&mut self, Event { id, msg }: Event) {
         if let Some(submission) = self.submissions.get_mut(&id) {
             submission.handle_event(&self.client, msg).await;
+        } else if matches!(
+            &msg,
+            EventMsg::SessionConfigured(..) | EventMsg::ThreadNameUpdated(..)
+        ) {
+            match msg {
+                EventMsg::SessionConfigured(event) => {
+                    send_session_title_update(&self.client, event.thread_name);
+                }
+                EventMsg::ThreadNameUpdated(event) => {
+                    send_session_title_update(&self.client, event.thread_name);
+                }
+                _ => unreachable!(),
+            }
         } else {
             warn!("Received event for unknown submission ID: {id} {msg:?}");
         }
+    }
+}
+
+fn send_session_title_update(client: &SessionClient, title: Option<String>) {
+    if let Some(title) = title {
+        client.send_notification(SessionUpdate::SessionInfoUpdate(
+            SessionInfoUpdate::new().title(title),
+        ));
     }
 }
 
@@ -4031,7 +4150,7 @@ mod tests {
 
     use agent_client_protocol::schema::{RequestPermissionResponse, TextContent};
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
-    use codex_protocol::config_types::ModeKind;
+    use codex_protocol::{ThreadId, config_types::ModeKind, protocol::ThreadNameUpdatedEvent};
     use tokio::sync::{Mutex, Notify, mpsc::UnboundedSender};
 
     use super::*;
@@ -4088,6 +4207,68 @@ mod tests {
         ));
         let ops = thread.ops.lock().unwrap();
         assert_eq!(ops.as_slice(), &[Op::Compact]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rename_sends_title_update() -> anyhow::Result<()> {
+        let (session_id, client, thread, message_tx, _handle) = setup().await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["/rename My New Thread".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let stop_reason = prompt_response_rx.await??.await??;
+        assert_eq!(stop_reason, StopReason::EndTurn);
+        drop(message_tx);
+
+        let ops = thread.ops.lock().unwrap();
+        assert!(matches!(
+            ops.as_slice(),
+            [Op::SetThreadName { name }] if name == "My New Thread"
+        ));
+
+        let notifications = client.notifications.lock().unwrap();
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::SessionInfoUpdate(update)
+                    if update.title.value() == Some(&"My New Thread".to_string())
+            )
+        }));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replay_thread_name_sends_title_update() -> anyhow::Result<()> {
+        let (_session_id, client, _, message_tx, _handle) = setup().await?;
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::ReplayHistory {
+            history: vec![RolloutItem::EventMsg(EventMsg::ThreadNameUpdated(
+                ThreadNameUpdatedEvent {
+                    thread_id: ThreadId::new(),
+                    thread_name: Some("Persisted Thread Name".to_string()),
+                },
+            ))],
+            response_tx,
+        })?;
+
+        response_rx.await??;
+        drop(message_tx);
+
+        let notifications = client.notifications.lock().unwrap();
+        assert!(notifications.iter().any(|notification| {
+            matches!(
+                &notification.update,
+                SessionUpdate::SessionInfoUpdate(update)
+                    if update.title.value() == Some(&"Persisted Thread Name".to_string())
+            )
+        }));
 
         Ok(())
     }
@@ -4766,6 +4947,17 @@ mod tests {
                     | Op::RequestPermissionsResponse { .. }
                     | Op::PatchApproval { .. }
                     | Op::Interrupt => {}
+                    Op::SetThreadName { name } => {
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::ThreadNameUpdated(ThreadNameUpdatedEvent {
+                                    thread_id: ThreadId::new(),
+                                    thread_name: Some(name),
+                                }),
+                            })
+                            .unwrap();
+                    }
                     Op::Shutdown => {
                         if let Some(active_prompt_id) = self.active_prompt_id.lock().unwrap().take()
                         {


### PR DESCRIPTION
Wire Codex thread names through ACP session title updates and add a /rename command.

**Changes:**
- Prefer persisted Codex thread names when listing sessions
- Send ACP title updates for live, loaded, and replayed Codex thread-name events
- Add `/rename <title>` to submit `SetThreadName` and complete after Codex confirms the rename