### PR TITLE
Wait for shutdown completion before closing ACP sessions

### DIFF
--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -31,8 +31,9 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
+    time::Duration,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::thread::Thread;
@@ -277,6 +278,26 @@ impl CodexAgent {
             )
             .connect_to(transport)
             .await
+    }
+
+    pub async fn shutdown_sessions(&self) {
+        let sessions = {
+            let mut sessions = self.sessions.lock().unwrap();
+            sessions.drain().collect::<Vec<_>>()
+        };
+        self.session_roots.lock().unwrap().clear();
+
+        if sessions.is_empty() {
+            return;
+        }
+
+        for (session_id, thread) in &sessions {
+            if let Err(err) = thread.request_shutdown().await {
+                warn!("Error requesting session shutdown for {session_id}: {err:?}");
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
     }
 
     fn session_id_from_thread_id(thread_id: ThreadId) -> SessionId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,11 @@
 use agent_client_protocol::ByteStreams;
 use codex_core::config::{Config, ConfigOverrides};
 use codex_utils_cli::CliConfigOverrides;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing_subscriber::EnvFilter;
 
@@ -67,13 +70,142 @@ pub async fn run_main(
     let stdin = tokio::io::stdin().compat();
     let stdout = tokio::io::stdout().compat_write();
 
-    agent
-        .serve(ByteStreams::new(stdout, stdin))
-        .await
-        .map_err(|e| std::io::Error::other(format!("ACP error: {e}")))?;
+    enum ServeOutcome {
+        Result(agent_client_protocol::Result<()>),
+        Signal,
+    }
+
+    let serve_outcome = {
+        let serve = agent.clone().serve(ByteStreams::new(stdout, stdin));
+        tokio::pin!(serve);
+
+        #[cfg(unix)]
+        {
+            let mut terminate =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+
+            tokio::select! {
+                result = &mut serve => ServeOutcome::Result(result),
+                _ = tokio::signal::ctrl_c() => ServeOutcome::Signal,
+                _ = terminate.recv() => ServeOutcome::Signal,
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            tokio::select! {
+                result = &mut serve => ServeOutcome::Result(result),
+                _ = tokio::signal::ctrl_c() => ServeOutcome::Signal,
+            }
+        }
+    };
+
+    agent.shutdown_sessions().await;
+
+    match serve_outcome {
+        ServeOutcome::Result(result) => {
+            result.map_err(|e| std::io::Error::other(format!("ACP error: {e}")))?;
+        }
+        ServeOutcome::Signal => {
+            terminate_descendant_processes();
+            std::process::exit(0);
+        }
+    }
 
     Ok(())
 }
+
+#[cfg(unix)]
+fn terminate_descendant_processes() {
+    let current_pid = std::process::id() as i32;
+    let output = match Command::new("ps")
+        .args(["-axo", "pid=,ppid=,pgid="])
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            tracing::warn!("Failed to list child processes during shutdown: {err}");
+            return;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut children_by_parent = HashMap::<i32, Vec<(i32, i32)>>::new();
+    let mut pgid_by_pid = HashMap::<i32, i32>::new();
+
+    for line in stdout.lines() {
+        let fields = line
+            .split_whitespace()
+            .filter_map(|field| field.parse::<i32>().ok())
+            .collect::<Vec<_>>();
+
+        let [pid, ppid, pgid] = fields.as_slice() else {
+            continue;
+        };
+
+        children_by_parent
+            .entry(*ppid)
+            .or_default()
+            .push((*pid, *pgid));
+        pgid_by_pid.insert(*pid, *pgid);
+    }
+
+    let current_pgid = pgid_by_pid.get(&current_pid).copied();
+    let mut descendants = Vec::<(i32, i32)>::new();
+    let mut stack = children_by_parent
+        .get(&current_pid)
+        .cloned()
+        .unwrap_or_default();
+
+    while let Some((pid, pgid)) = stack.pop() {
+        descendants.push((pid, pgid));
+        if let Some(children) = children_by_parent.get(&pid) {
+            stack.extend(children.iter().copied());
+        }
+    }
+
+    if descendants.is_empty() {
+        return;
+    }
+
+    let process_groups = descendants
+        .iter()
+        .map(|(_, pgid)| *pgid)
+        .filter(|pgid| *pgid > 1 && Some(*pgid) != current_pgid)
+        .collect::<HashSet<_>>();
+
+    for pgid in &process_groups {
+        kill_process("-TERM", &format!("-{pgid}"));
+    }
+
+    for (pid, _) in &descendants {
+        kill_process("-TERM", &pid.to_string());
+    }
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    for pgid in &process_groups {
+        kill_process("-KILL", &format!("-{pgid}"));
+    }
+
+    for (pid, _) in descendants {
+        kill_process("-KILL", &pid.to_string());
+    }
+}
+
+#[cfg(unix)]
+fn kill_process(signal: &str, target: &str) {
+    drop(
+        Command::new("kill")
+            .args([signal, target])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+    );
+}
+
+#[cfg(not(unix))]
+fn terminate_descendant_processes() {}
 
 // Re-export the MCP server types for compatibility
 pub use codex_mcp_server::{

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -370,6 +370,14 @@ impl Thread {
         // prompt callers observe a clean cancellation instead of a dropped response channel.
         Ok(())
     }
+
+    pub async fn request_shutdown(&self) -> Result<(), Error> {
+        self.thread
+            .submit(Op::Shutdown)
+            .await
+            .map(|_| ())
+            .map_err(|e| Error::from(anyhow::anyhow!(e)))
+    }
 }
 
 enum PendingPermissionRequest {
@@ -2592,6 +2600,8 @@ struct ThreadActor<A> {
     resolution_rx: mpsc::UnboundedReceiver<ThreadMessage>,
     /// Last config options state we emitted to the client, used for deduping updates.
     last_sent_config_options: Option<Vec<SessionConfigOption>>,
+    /// Response waiting for Codex core to emit `ShutdownComplete`.
+    pending_shutdown: Option<oneshot::Sender<Result<(), Error>>>,
 }
 
 impl<A: Auth> ThreadActor<A> {
@@ -2617,6 +2627,7 @@ impl<A: Auth> ThreadActor<A> {
             message_rx,
             resolution_rx,
             last_sent_config_options: None,
+            pending_shutdown: None,
         }
     }
 
@@ -2636,6 +2647,12 @@ impl<A: Auth> ThreadActor<A> {
                     Ok(event) => self.handle_event(event).await,
                     Err(e) => {
                         error!("Error getting next event: {:?}", e);
+                        if let Some(response_tx) = self.pending_shutdown.take() {
+                            drop(
+                                response_tx
+                                    .send(Err(Error::from(anyhow::anyhow!(e.to_string())))),
+                            );
+                        }
                         break;
                     }
                 }
@@ -2699,8 +2716,7 @@ impl<A: Auth> ThreadActor<A> {
                 drop(response_tx.send(result));
             }
             ThreadMessage::Shutdown { response_tx } => {
-                let result = self.handle_shutdown().await;
-                drop(response_tx.send(result));
+                self.handle_shutdown(response_tx).await;
             }
             ThreadMessage::ReplayHistory {
                 history,
@@ -3319,13 +3335,28 @@ impl<A: Auth> ThreadActor<A> {
         Ok(())
     }
 
-    async fn handle_shutdown(&mut self) -> Result<(), Error> {
+    async fn handle_shutdown(&mut self, response_tx: oneshot::Sender<Result<(), Error>>) {
+        if self.pending_shutdown.is_some() {
+            drop(response_tx.send(Err(
+                Error::internal_error().data("shutdown already in progress"),
+            )));
+            return;
+        }
+
         self.abort_pending_interactions();
-        self.thread
+        match self
+            .thread
             .submit(Op::Shutdown)
             .await
-            .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
-        Ok(())
+            .map_err(|e| Error::from(anyhow::anyhow!(e)))
+        {
+            Ok(_) => {
+                self.pending_shutdown = Some(response_tx);
+            }
+            Err(err) => {
+                drop(response_tx.send(Err(err)));
+            }
+        }
     }
 
     fn abort_pending_interactions(&mut self) {
@@ -3645,9 +3676,15 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     async fn handle_event(&mut self, Event { id, msg }: Event) {
+        if matches!(&msg, EventMsg::ShutdownComplete) {
+            if let Some(response_tx) = self.pending_shutdown.take() {
+                drop(response_tx.send(Ok(())));
+            }
+        }
+
         if let Some(submission) = self.submissions.get_mut(&id) {
             submission.handle_event(&self.client, msg).await;
-        } else {
+        } else if !matches!(&msg, EventMsg::ShutdownComplete) {
             warn!("Received event for unknown submission ID: {id} {msg:?}");
         }
     }
@@ -4473,6 +4510,7 @@ mod tests {
     struct StubCodexThread {
         current_id: AtomicUsize,
         active_prompt_id: std::sync::Mutex<Option<String>>,
+        shutdown_complete_delay: std::sync::Mutex<Option<Duration>>,
         ops: std::sync::Mutex<Vec<Op>>,
         op_tx: mpsc::UnboundedSender<Event>,
         op_rx: Mutex<mpsc::UnboundedReceiver<Event>>,
@@ -4484,10 +4522,15 @@ mod tests {
             StubCodexThread {
                 current_id: AtomicUsize::new(0),
                 active_prompt_id: std::sync::Mutex::default(),
+                shutdown_complete_delay: std::sync::Mutex::default(),
                 ops: std::sync::Mutex::default(),
                 op_tx,
                 op_rx: Mutex::new(op_rx),
             }
+        }
+
+        fn delay_shutdown_complete(&self, delay: Duration) {
+            *self.shutdown_complete_delay.lock().unwrap() = Some(delay);
         }
     }
 
@@ -4782,6 +4825,23 @@ mod tests {
                                 })
                                 .unwrap();
                         }
+
+                        let delay = self
+                            .shutdown_complete_delay
+                            .lock()
+                            .unwrap()
+                            .unwrap_or_default();
+                        let op_tx = self.op_tx.clone();
+                        let event_id = id.to_string();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(delay).await;
+                            op_tx
+                                .send(Event {
+                                    id: event_id,
+                                    msg: EventMsg::ShutdownComplete,
+                                })
+                                .unwrap();
+                        });
                     }
                     _ => {
                         unimplemented!()
@@ -5315,6 +5375,49 @@ mod tests {
 
         let ops = conversation.ops.lock().unwrap();
         assert!(matches!(ops.last(), Some(Op::Shutdown)));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_thread_shutdown_waits_for_shutdown_complete() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        conversation.delay_shutdown_complete(Duration::from_millis(75));
+        let models_manager = Arc::new(StubModelsManager);
+        let config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation.clone(),
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
+        let handle = tokio::spawn(actor.spawn());
+        let thread = Thread {
+            thread: conversation.clone(),
+            message_tx,
+            _handle: handle,
+        };
+
+        let early_shutdown =
+            tokio::time::timeout(Duration::from_millis(20), thread.shutdown()).await;
+        assert!(
+            early_shutdown.is_err(),
+            "shutdown returned before Codex emitted ShutdownComplete"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Drafting a possible lifecycle fix for ACP shutdown cleanup. I am not fully sure this belongs in the ACP adapter versus lower in Codex/MCP process ownership, so keeping this as draft for discussion.

Fixes #252

**Changes:**
- Wait for `ShutdownComplete` on explicit `session/close`
- Best-effort shutdown active sessions when the adapter receives SIGTERM/ctrl-c
- Clean up remaining adapter-owned descendant processes on Unix signal exit
- Add regression coverage for delayed shutdown completion

**Validation:**
- `cargo test`
- Direct ACP validation with `chrome-devtools-mcp@latest` and `mcp__chrome_devtools__list_pages`; SIGTERM left no new MCP or Chrome profile PIDs