### PR TITLE
Fix O(N²) memory growth in exec_command_output_delta fallback

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2029,8 +2029,8 @@ impl PromptState {
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
             let data_str = String::from_utf8_lossy(&chunk).to_string();
 
-            let update = if client.supports_terminal_output(active_command) {
-                ToolCallUpdate::new(
+            if client.supports_terminal_output(active_command) {
+                let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
                     ToolCallUpdateFields::new(),
                 )
@@ -2040,27 +2040,15 @@ impl PromptState {
                         "terminal_id": call_id,
                         "data": data_str
                     }),
-                )]))
+                )]));
+                client.send_tool_call_update(update);
             } else {
+                // Fallback path (no terminal_output capability): accumulate locally
+                // and emit a single ToolCallUpdate at exec_command_end. Resending the
+                // entire accumulated buffer per chunk is O(N²) memory and crashes the
+                // process on large outputs (issue #225).
                 active_command.output.push_str(&data_str);
-                let content = match active_command.file_extension.as_deref() {
-                    Some("md") => active_command.output.clone(),
-                    Some(ext) => format!(
-                        "```{ext}\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                    None => format!(
-                        "```sh\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                };
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().content(vec![content.into()]),
-                )
-            };
-
-            client.send_tool_call_update(update);
+            }
         }
     }
 
@@ -2092,15 +2080,35 @@ impl PromptState {
                 ExecCommandStatus::Failed | ExecCommandStatus::Declined => ToolCallStatus::Failed,
             };
 
+            let supports_terminal = client.supports_terminal_output(&active_command);
+
+            let mut fields = ToolCallUpdateFields::new()
+                .status(status)
+                .raw_output(raw_output);
+
+            // For the non-terminal fallback path the per-chunk delta handler now
+            // accumulates silently (see exec_command_output_delta). Emit the full
+            // buffer here, exactly once, as a single content block. Skip the emission
+            // entirely when the command produced no output, so we don't surface an
+            // empty fenced code block to the client.
+            if !supports_terminal && !active_command.output.is_empty() {
+                let content = match active_command.file_extension.as_deref() {
+                    Some("md") => active_command.output.clone(),
+                    Some(ext) => format!(
+                        "```{ext}\n{}\n```\n",
+                        active_command.output.trim_end_matches('\n')
+                    ),
+                    None => format!(
+                        "```sh\n{}\n```\n",
+                        active_command.output.trim_end_matches('\n')
+                    ),
+                };
+                fields = fields.content(vec![content.into()]);
+            }
+
             client.send_tool_call_update(
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new()
-                        .status(status)
-                        .raw_output(raw_output),
-                )
-                .meta(client.supports_terminal_output(&active_command).then(
-                    || {
+                ToolCallUpdate::new(active_command.tool_call_id.clone(), fields).meta(
+                    supports_terminal.then(|| {
                         Meta::from_iter([(
                             "terminal_exit".into(),
                             serde_json::json!({
@@ -2109,8 +2117,8 @@ impl PromptState {
                                 "signal": null
                             }),
                         )])
-                    },
-                )),
+                    }),
+                ),
             );
         }
     }


### PR DESCRIPTION
Closes #225.

## Problem

When the ACP client does not advertise `terminal_output` capability, `exec_command_output_delta` accumulates each chunk into `active_command.output` and then re-sends the **entire growing buffer** as a `ToolCallUpdate` content block on every chunk. The notification channel is `mpsc::unbounded()`, so for `N` chunks the in-flight queue holds `1 + 2 + … + N` copies of the buffer.

This path is always taken for `rg`, `find`, and `fd` (classified as `Search` / `ListFiles` by the upstream parser), regardless of client capability. Real-world reports on the issue:

- 16 GB → 39 GB swap in 60 s on 0.11.1, single broad `rg` over a vault.
- macOS `memorystatus: killing largest compressed process codex-acp 46313 MB` on 0.12.0 in Zed.
- 27 GB RSS / 485 GB VSZ before SIGKILL on 0.13.0 in a routine session.

## Fix

Match `claude-agent-acp`'s behavior in the non-terminal fallback path:

- `exec_command_output_delta` only accumulates into `active_command.output`. No per-chunk `ToolCallUpdate` is emitted.
- `exec_command_end` emits one `ToolCallUpdate` carrying the full formatted content block, using the same `file_extension` formatter that previously ran per chunk. Skipped when the command produced no output, to avoid surfacing an empty fenced code block.
- The terminal-output fast path (clients that advertise `terminal_output`) is untouched — it already streamed only the latest chunk via `meta`.

Total wire traffic for a non-terminal command goes from `O(N²)` to `O(N)`. Final ToolCall state is identical to upstream, modulo per-chunk noise.

## Verification

- `cargo build --release` and `cargo clippy --release -- -D warnings` clean on `aarch64-apple-darwin`.
- Stress run of 12 broad `rg -n --no-heading` searches across an 8,400+ TS-file monorepo, no path filter, no `head` truncation, via an ACP client that does **not** advertise `terminal_output`. Peak `codex-acp` RSS held at **~84 MB** end-to-end (started 56 MB, climbed to 84, fell back to 80). Pre-patch the same workload reliably crashed the process with multi-GB RSS.

## Out of scope

- `terminal_interaction` (stdin echo path, around `src/thread.rs:2127`) has the same accumulate-and-resend shape but with tiny stdin payloads. Left as a follow-up so the fix here stays bounded to the symptom in #225.
- The `raw_output` field on `exec_command_end` still contains the full `ExecCommandEndEvent` (one extra `O(N)` copy at completion). Not the source of the quadratic blow-up; removing it would be a wider behavior change for client consumers.