### PR TITLE
Stop output buffer resend in terminal_interaction stdin path

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2133,8 +2133,8 @@ impl PromptState {
         let stdin = format!("\n{stdin}\n");
         // Stream output bytes to the display-only terminal via ToolCallUpdate meta.
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
-            let update = if client.supports_terminal_output(active_command) {
-                ToolCallUpdate::new(
+            if client.supports_terminal_output(active_command) {
+                let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
                     ToolCallUpdateFields::new(),
                 )
@@ -2144,27 +2144,15 @@ impl PromptState {
                         "terminal_id": call_id,
                         "data": stdin
                     }),
-                )]))
+                )]));
+                client.send_tool_call_update(update);
             } else {
+                // Fallback path: accumulate stdin into the active command buffer and
+                // defer emission to exec_command_end. Emitting per stdin event would
+                // re-send the entire output+stdin buffer each time and reintroduce the
+                // O(N²) growth fixed in the delta path.
                 active_command.output.push_str(&stdin);
-                let content = match active_command.file_extension.as_deref() {
-                    Some("md") => active_command.output.clone(),
-                    Some(ext) => format!(
-                        "```{ext}\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                    None => format!(
-                        "```sh\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                };
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().content(vec![content.into()]),
-                )
-            };
-
-            client.send_tool_call_update(update);
+            }
         }
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2029,8 +2029,8 @@ impl PromptState {
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
             let data_str = String::from_utf8_lossy(&chunk).to_string();
 
-            let update = if client.supports_terminal_output(active_command) {
-                ToolCallUpdate::new(
+            if client.supports_terminal_output(active_command) {
+                let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
                     ToolCallUpdateFields::new(),
                 )
@@ -2040,27 +2040,15 @@ impl PromptState {
                         "terminal_id": call_id,
                         "data": data_str
                     }),
-                )]))
+                )]));
+                client.send_tool_call_update(update);
             } else {
+                // Fallback path (no terminal_output capability): accumulate locally
+                // and emit a single ToolCallUpdate at exec_command_end. Resending the
+                // entire accumulated buffer per chunk is O(N²) memory and crashes the
+                // process on large outputs (issue #225).
                 active_command.output.push_str(&data_str);
-                let content = match active_command.file_extension.as_deref() {
-                    Some("md") => active_command.output.clone(),
-                    Some(ext) => format!(
-                        "```{ext}\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                    None => format!(
-                        "```sh\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                };
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().content(vec![content.into()]),
-                )
-            };
-
-            client.send_tool_call_update(update);
+            }
         }
     }
 
@@ -2092,15 +2080,35 @@ impl PromptState {
                 ExecCommandStatus::Failed | ExecCommandStatus::Declined => ToolCallStatus::Failed,
             };
 
+            let supports_terminal = client.supports_terminal_output(&active_command);
+
+            let mut fields = ToolCallUpdateFields::new()
+                .status(status)
+                .raw_output(raw_output);
+
+            // For the non-terminal fallback path the per-chunk delta handler now
+            // accumulates silently (see exec_command_output_delta). Emit the full
+            // buffer here, exactly once, as a single content block. Skip the emission
+            // entirely when the command produced no output, so we don't surface an
+            // empty fenced code block to the client.
+            if !supports_terminal && !active_command.output.is_empty() {
+                let content = match active_command.file_extension.as_deref() {
+                    Some("md") => active_command.output.clone(),
+                    Some(ext) => format!(
+                        "```{ext}\n{}\n```\n",
+                        active_command.output.trim_end_matches('\n')
+                    ),
+                    None => format!(
+                        "```sh\n{}\n```\n",
+                        active_command.output.trim_end_matches('\n')
+                    ),
+                };
+                fields = fields.content(vec![content.into()]);
+            }
+
             client.send_tool_call_update(
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new()
-                        .status(status)
-                        .raw_output(raw_output),
-                )
-                .meta(client.supports_terminal_output(&active_command).then(
-                    || {
+                ToolCallUpdate::new(active_command.tool_call_id.clone(), fields).meta(
+                    supports_terminal.then(|| {
                         Meta::from_iter([(
                             "terminal_exit".into(),
                             serde_json::json!({
@@ -2109,8 +2117,8 @@ impl PromptState {
                                 "signal": null
                             }),
                         )])
-                    },
-                )),
+                    }),
+                ),
             );
         }
     }


### PR DESCRIPTION
Follow-up to #269.

`terminal_interaction`'s non-terminal fallback has the same accumulate-and-resend shape that #269 fixed in `exec_command_output_delta` — every stdin event re-sends the entire `active_command.output` (output bytes accumulated by the delta handler **plus** every prior stdin echo) as a `ToolCallUpdate` content block. Stdin payloads are tiny on their own, but the buffer being resent is the full output buffer, so the same O(N²) growth pattern applies whenever an interactive command interleaves output streaming with stdin injections.

## Fix

Mirror the prior change: in the non-terminal fallback, append `stdin` into `active_command.output` and let `exec_command_end` emit the full content block exactly once at completion. The terminal-output fast path (clients that advertise the capability) is untouched.

## Stacking

This PR is stacked on top of #269 — it depends on the new `exec_command_end` content emission introduced there to surface stdin in the final ToolCall update. If #269 lands first this rebases trivially; if a single PR is preferred I'm happy to squash.

## Verification

- `cargo build --release` and `cargo clippy --release -- -D warnings` clean on `aarch64-apple-darwin` with both patches applied.
- Re-ran the same broad-`rg` regression workload from #269 against the layered binary: 8 patterns over the same monorepo + recursive `find`, completed in 32 s, peak `codex-acp` RSS held at **~93 MB** — flat profile, no regression.