### PR TITLE
Add /rename builtin slash command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,8 +199,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
+source = "git+https://github.com/daniel-agentee/rust-sdk?rev=d28b51bab500b8aad1b38da658c04f705dcd17c3#d28b51bab500b8aad1b38da658c04f705dcd17c3"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -221,8 +220,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-derive"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
+source = "git+https://github.com/daniel-agentee/rust-sdk?rev=d28b51bab500b8aad1b38da658c04f705dcd17c3#d28b51bab500b8aad1b38da658c04f705dcd17c3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -231,8 +229,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-schema"
 version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+source = "git+https://github.com/daniel-agentee/agent-client-protocol?rev=23977c0193c786d0747464a46b5a561ca15c62e2#23977c0193c786d0747464a46b5a561ca15c62e2"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
@@ -350,7 +347,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -361,7 +358,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3720,7 +3717,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3988,7 +3985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5782,7 +5779,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6180,7 +6177,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6334,6 +6331,8 @@ version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6952,7 +6951,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7651,6 +7650,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -8772,7 +8777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8831,7 +8836,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9617,7 +9622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10150,7 +10155,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10214,7 +10219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10854,7 +10859,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11388,7 +11393,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.14.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
  "async-lock",
@@ -3443,13 +3443,13 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6334,8 +6334,6 @@ version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -7629,9 +7627,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -7653,12 +7651,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -8914,9 +8906,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -11118,11 +11110,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -11131,7 +11123,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -11796,12 +11788,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4063,7 +4063,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8764,7 +8764,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,5 +62,13 @@ unused = "warn"
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
 
+# Temporary: pull `session/setTitle` support before it ships on crates.io.
+# Remove both entries once `agent-client-protocol-schema` and `agent-client-protocol`
+# publish releases containing the new types. Tracking:
+#   - https://github.com/agentclientprotocol/agent-client-protocol/pull/1199 (schema)
+#   - https://github.com/agentclientprotocol/rust-sdk/pull/164 (routing)
+agent-client-protocol-schema = { git = "https://github.com/daniel-agentee/agent-client-protocol", rev = "23977c0193c786d0747464a46b5a561ca15c62e2" }
+agent-client-protocol = { git = "https://github.com/daniel-agentee/rust-sdk", rev = "d28b51bab500b8aad1b38da658c04f705dcd17c3" }
+
 [patch."https://github.com/openai/codex"]
 codex-utils-pty = { path = "vendor/codex-utils-pty" }

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -9,7 +9,7 @@ use acp::schema::{
     ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionCloseCapabilities,
     SessionId, SessionInfo, SessionListCapabilities, SessionResumeCapabilities,
     SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-    SetSessionModeResponse,
+    SetSessionModeResponse, SetSessionTitleRequest, SetSessionTitleResponse,
 };
 use acp::{Agent, Client, ConnectTo, ConnectionTo, Error};
 use agent_client_protocol as acp;
@@ -280,6 +280,21 @@ impl CodexAgent {
                         let agent = agent.clone();
                         cx.spawn(async move {
                             responder.respond_with_result(agent.set_session_mode(request).await)
+                        })?;
+                        Ok(())
+                    }
+                },
+                acp::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let agent = agent.clone();
+                    async move |request: SetSessionTitleRequest,
+                                responder,
+                                cx: ConnectionTo<Client>| {
+                        let agent = agent.clone();
+                        cx.spawn(async move {
+                            responder.respond_with_result(agent.set_session_title(request).await)
                         })?;
                         Ok(())
                     }
@@ -823,6 +838,37 @@ impl CodexAgent {
             .set_mode(args.mode_id)
             .await?;
         Ok(SetSessionModeResponse::default())
+    }
+
+    async fn set_session_title(
+        &self,
+        args: SetSessionTitleRequest,
+    ) -> Result<SetSessionTitleResponse, Error> {
+        info!("Setting session title for session: {}", args.session_id);
+
+        let thread = self.get_thread(&args.session_id)?;
+        let thread_id =
+            ThreadId::from_string(&args.session_id.0).map_err(Error::into_internal_error)?;
+
+        if let Some(state_db) = self.state_db.as_deref() {
+            match state_db.update_thread_title(thread_id, &args.title).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    debug!(
+                        "Thread metadata unavailable before title update for session: {}",
+                        args.session_id
+                    );
+                }
+                Err(err) => {
+                    return Err(Error::internal_error()
+                        .data(format!("failed to update thread title: {err}")));
+                }
+            }
+        }
+
+        thread.set_title(args.title).await?;
+
+        Ok(SetSessionTitleResponse::default())
     }
 
     async fn set_session_config_option(

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -879,7 +879,10 @@ impl CodexAgent {
         }
 
         if let Some(thread) = loaded_thread {
-            thread.set_title(title).await?;
+            let notification_title = self
+                .notification_title_for_update(thread_id, &title)
+                .await?;
+            thread.set_title(title, notification_title).await?;
         } else {
             if !title_updated_in_state {
                 let rollout_path = find_thread_path_by_id_str(
@@ -909,6 +912,9 @@ impl CodexAgent {
                 }
             }
 
+            let notification_title = self
+                .notification_title_for_update(thread_id, &title)
+                .await?;
             append_thread_name(&self.config.codex_home, thread_id, &title)
                 .await
                 .map_err(|err| {
@@ -916,11 +922,41 @@ impl CodexAgent {
                 })?;
             notify_client(SessionNotification::new(
                 session_id,
-                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title(title)),
+                SessionUpdate::SessionInfoUpdate(
+                    SessionInfoUpdate::new().title(notification_title),
+                ),
             ))?;
         }
 
         Ok(SetSessionTitleResponse::default())
+    }
+
+    async fn notification_title_for_update(
+        &self,
+        thread_id: ThreadId,
+        title: &str,
+    ) -> Result<Option<String>, Error> {
+        if !title.trim().is_empty() {
+            return Ok(Some(title.to_string()));
+        }
+
+        if let Some(state_db) = self.state_db.as_deref() {
+            match state_db.get_thread(thread_id).await {
+                Ok(Some(metadata)) => {
+                    return Ok(metadata
+                        .first_user_message
+                        .as_deref()
+                        .and_then(format_session_title));
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(Error::internal_error()
+                        .data(format!("failed to read thread title fallback: {err}")));
+                }
+            }
+        }
+
+        Ok(None)
     }
 
     async fn set_session_config_option(
@@ -1076,7 +1112,11 @@ mod tests {
         );
     }
 
-    fn write_minimal_rollout_with_id(codex_home: &Path, id: Uuid) -> anyhow::Result<PathBuf> {
+    fn write_minimal_rollout_with_id(
+        codex_home: &Path,
+        id: Uuid,
+        user_message: Option<&str>,
+    ) -> anyhow::Result<PathBuf> {
         let sessions = codex_home.join("sessions/2024/01/01");
         std::fs::create_dir_all(&sessions)?;
 
@@ -1099,6 +1139,22 @@ mod tests {
             })
         )?;
 
+        if let Some(message) = user_message {
+            writeln!(
+                writer,
+                "{}",
+                serde_json::json!({
+                    "timestamp": "2024-01-01T00:00:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "user_message",
+                        "message": message,
+                        "kind": "plain"
+                    }
+                })
+            )?;
+        }
+
         Ok(file)
     }
 
@@ -1118,7 +1174,7 @@ mod tests {
         let agent = CodexAgent::new(config, None).await?;
         let thread_uuid = Uuid::new_v4();
         let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
-        write_minimal_rollout_with_id(&codex_home, thread_uuid)?;
+        write_minimal_rollout_with_id(&codex_home, thread_uuid, None)?;
         let session_id = SessionId::new(thread_id.to_string());
         let notifications = Arc::new(Mutex::new(Vec::new()));
         let captured_notifications = notifications.clone();
@@ -1152,6 +1208,68 @@ mod tests {
                     )
             }),
             "expected SessionInfoUpdate for unloaded rename; got: {notifications:#?}"
+        );
+        drop(notifications);
+
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_session_title_clear_notifies_with_fallback_title() -> anyhow::Result<()> {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-clear-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        config.codex_home = codex_home.clone().try_into()?;
+
+        let agent = CodexAgent::new(config, None).await?;
+        let thread_uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
+        write_minimal_rollout_with_id(
+            &codex_home,
+            thread_uuid,
+            Some("Summarize the quarterly plan"),
+        )?;
+        let session_id = SessionId::new(thread_id.to_string());
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let captured_notifications = notifications.clone();
+
+        agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id.clone(), "   "),
+                |notification| {
+                    captured_notifications.lock().unwrap().push(notification);
+                    Ok(())
+                },
+            )
+            .await?;
+
+        assert_eq!(
+            codex_core::find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
+            Some("   ".to_string())
+        );
+
+        let notifications = notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|notification| {
+                notification.session_id == session_id
+                    && matches!(
+                        &notification.update,
+                        SessionUpdate::SessionInfoUpdate(update)
+                            if matches!(
+                                &update.title,
+                                MaybeUndefined::Value(title) if title == "Summarize the quarterly plan"
+                            )
+                    )
+            }),
+            "expected SessionInfoUpdate with fallback title after clearing custom title; got: {notifications:#?}"
         );
         drop(notifications);
 

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -8,9 +8,9 @@ use acp::schema::{
     NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion,
     ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionCloseCapabilities,
     SessionId, SessionInfo, SessionInfoUpdate, SessionListCapabilities, SessionNotification,
-    SessionResumeCapabilities, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
-    SetSessionTitleRequest, SetSessionTitleResponse,
+    SessionResumeCapabilities, SessionSetTitleCapabilities, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse, SetSessionTitleRequest, SetSessionTitleResponse,
 };
 use acp::{Agent, Client, ConnectTo, ConnectionTo, Error};
 use agent_client_protocol as acp;
@@ -480,7 +480,8 @@ impl CodexAgent {
         agent_capabilities.session_capabilities = SessionCapabilities::new()
             .close(SessionCloseCapabilities::new())
             .list(SessionListCapabilities::new())
-            .resume(SessionResumeCapabilities::new());
+            .resume(SessionResumeCapabilities::new())
+            .set_title(SessionSetTitleCapabilities::new());
 
         let mut auth_methods = vec![
             CodexAuthMethod::ChatGpt.into(),
@@ -853,6 +854,7 @@ impl CodexAgent {
         notify_client: impl FnOnce(SessionNotification) -> Result<(), Error>,
     ) -> Result<SetSessionTitleResponse, Error> {
         info!("Setting session title for session: {}", args.session_id);
+        self.check_auth().await?;
 
         let session_id = args.session_id;
         let title = args.title;
@@ -879,9 +881,7 @@ impl CodexAgent {
         }
 
         if let Some(thread) = loaded_thread {
-            let notification_title = self
-                .notification_title_for_update(thread_id, &title)
-                .await?;
+            let notification_title = notification_title_for_update(&title);
             thread.set_title(title, notification_title).await?;
         } else {
             if !title_updated_in_state {
@@ -912,9 +912,7 @@ impl CodexAgent {
                 }
             }
 
-            let notification_title = self
-                .notification_title_for_update(thread_id, &title)
-                .await?;
+            let notification_title = notification_title_for_update(&title);
             append_thread_name(&self.config.codex_home, thread_id, &title)
                 .await
                 .map_err(|err| {
@@ -929,34 +927,6 @@ impl CodexAgent {
         }
 
         Ok(SetSessionTitleResponse::default())
-    }
-
-    async fn notification_title_for_update(
-        &self,
-        thread_id: ThreadId,
-        title: &str,
-    ) -> Result<Option<String>, Error> {
-        if !title.trim().is_empty() {
-            return Ok(Some(title.to_string()));
-        }
-
-        if let Some(state_db) = self.state_db.as_deref() {
-            match state_db.get_thread(thread_id).await {
-                Ok(Some(metadata)) => {
-                    return Ok(metadata
-                        .first_user_message
-                        .as_deref()
-                        .and_then(format_session_title));
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    return Err(Error::internal_error()
-                        .data(format!("failed to read thread title fallback: {err}")));
-                }
-            }
-        }
-
-        Ok(None)
     }
 
     async fn set_session_config_option(
@@ -1072,10 +1042,19 @@ fn format_session_title(message: &str) -> Option<String> {
 }
 
 fn stored_session_title(name: Option<&str>, preview: &str) -> Option<String> {
-    [name, Some(preview)]
-        .into_iter()
-        .flatten()
-        .find_map(format_session_title)
+    match name {
+        Some(name) if name.trim().is_empty() => None,
+        Some(name) => format_session_title(name),
+        None => format_session_title(preview),
+    }
+}
+
+fn notification_title_for_update(title: &str) -> Option<String> {
+    if title.trim().is_empty() {
+        None
+    } else {
+        Some(title.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -1102,15 +1081,16 @@ mod tests {
     }
 
     #[test]
-    fn stored_session_title_falls_back_to_preview() {
+    fn stored_session_title_falls_back_to_preview_when_name_is_absent() {
         assert_eq!(
             stored_session_title(None, "preview"),
             Some("preview".to_string())
         );
-        assert_eq!(
-            stored_session_title(Some("  "), "preview"),
-            Some("preview".to_string())
-        );
+    }
+
+    #[test]
+    fn stored_session_title_preserves_explicitly_cleared_name() {
+        assert_eq!(stored_session_title(Some("  "), "preview"), None);
     }
 
     fn write_minimal_rollout_with_id(
@@ -1171,6 +1151,7 @@ mod tests {
         )
         .await?;
         config.codex_home = codex_home.clone().try_into()?;
+        config.model_provider_id = "test-provider".to_string();
 
         let agent = CodexAgent::new(config, None).await?;
         let thread_uuid = Uuid::new_v4();
@@ -1218,7 +1199,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_session_title_clear_notifies_with_fallback_title() -> anyhow::Result<()> {
+    async fn set_session_title_persists_db_backed_unloaded_session_to_name_index()
+    -> anyhow::Result<()> {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-db-backed-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        config.codex_home = codex_home.clone().try_into()?;
+        config.model_provider_id = "test-provider".to_string();
+
+        let agent = CodexAgent::new(config, None).await?;
+        let thread_uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
+        let rollout_path = write_minimal_rollout_with_id(&codex_home, thread_uuid, None)?;
+        let session_id = SessionId::new(thread_id.to_string());
+
+        agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id.clone(), "Seed DB metadata"),
+                |_| Ok(()),
+            )
+            .await?;
+
+        std::fs::remove_file(rollout_path)?;
+        std::fs::remove_file(codex_home.join("session_index.jsonl"))?;
+
+        agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id, "DB backed title"),
+                |_| Ok(()),
+            )
+            .await?;
+
+        assert_eq!(
+            find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
+            Some("DB backed title".to_string())
+        );
+
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_session_title_clear_notifies_with_cleared_title() -> anyhow::Result<()> {
         let codex_home =
             std::env::temp_dir().join(format!("codex-acp-clear-title-{}", Uuid::new_v4()));
         std::fs::create_dir_all(&codex_home)?;
@@ -1229,6 +1258,7 @@ mod tests {
         )
         .await?;
         config.codex_home = codex_home.clone().try_into()?;
+        config.model_provider_id = "test-provider".to_string();
 
         let agent = CodexAgent::new(config, None).await?;
         let thread_uuid = Uuid::new_v4();
@@ -1264,13 +1294,10 @@ mod tests {
                     && matches!(
                         &notification.update,
                         SessionUpdate::SessionInfoUpdate(update)
-                            if matches!(
-                                &update.title,
-                                MaybeUndefined::Value(title) if title == "Summarize the quarterly plan"
-                            )
+                            if matches!(&update.title, MaybeUndefined::Null)
                     )
             }),
-            "expected SessionInfoUpdate with fallback title after clearing custom title; got: {notifications:#?}"
+            "expected SessionInfoUpdate with cleared title after clearing custom title; got: {notifications:#?}"
         );
         drop(notifications);
 
@@ -1291,6 +1318,7 @@ mod tests {
         )
         .await?;
         config.codex_home = codex_home.clone().try_into()?;
+        config.model_provider_id = "test-provider".to_string();
 
         let agent = CodexAgent::new(config, None).await?;
         let thread_id = ThreadId::default();
@@ -1315,6 +1343,55 @@ mod tests {
         assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
         assert_eq!(
             codex_core::find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
+            None
+        );
+        assert!(notifications.lock().unwrap().is_empty());
+
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_session_title_requires_authentication_before_metadata_update() -> anyhow::Result<()>
+    {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-auth-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        config.codex_home = codex_home.clone().try_into()?;
+        config.model_provider_id = "openai".to_string();
+
+        let agent = CodexAgent::new(config, None).await?;
+        let thread_uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
+        write_minimal_rollout_with_id(&codex_home, thread_uuid, None)?;
+        let session_id = SessionId::new(thread_id.to_string());
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let captured_notifications = notifications.clone();
+
+        let result = agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id, "Unauthenticated title"),
+                |notification| {
+                    captured_notifications.lock().unwrap().push(notification);
+                    Ok(())
+                },
+            )
+            .await;
+
+        let err = match result {
+            Ok(_) => panic!("expected unauthenticated title update to be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.code, acp::ErrorCode::AuthRequired);
+        assert_eq!(
+            find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
             None
         );
         assert!(notifications.lock().unwrap().is_empty());

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -7,15 +7,16 @@ use acp::schema::{
     McpCapabilities, McpServer, McpServerHttp, McpServerStdio, NewSessionRequest,
     NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion,
     ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities, SessionCloseCapabilities,
-    SessionId, SessionInfo, SessionListCapabilities, SessionResumeCapabilities,
-    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
-    SetSessionModeResponse, SetSessionTitleRequest, SetSessionTitleResponse,
+    SessionId, SessionInfo, SessionInfoUpdate, SessionListCapabilities, SessionNotification,
+    SessionResumeCapabilities, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse,
+    SetSessionTitleRequest, SetSessionTitleResponse,
 };
 use acp::{Agent, Client, ConnectTo, ConnectionTo, Error};
 use agent_client_protocol as acp;
 use codex_config::{DEFAULT_MCP_SERVER_ENVIRONMENT_ID, McpServerConfig, McpServerTransportConfig};
 use codex_core::{
-    NewThread, RolloutRecorder, StateDbHandle, ThreadManager, config::Config,
+    NewThread, RolloutRecorder, StateDbHandle, ThreadManager, append_thread_name, config::Config,
     find_thread_path_by_id_str, init_state_db, resolve_installation_id, thread_store_from_config,
 };
 use codex_exec_server::{EnvironmentManager, ExecServerRuntimePaths};
@@ -293,8 +294,15 @@ impl CodexAgent {
                                 responder,
                                 cx: ConnectionTo<Client>| {
                         let agent = agent.clone();
+                        let notification_cx = cx.clone();
                         cx.spawn(async move {
-                            responder.respond_with_result(agent.set_session_title(request).await)
+                            responder.respond_with_result(
+                                agent
+                                    .set_session_title(request, |notification| {
+                                        notification_cx.send_notification(notification)
+                                    })
+                                    .await,
+                            )
                         })?;
                         Ok(())
                     }
@@ -326,13 +334,12 @@ impl CodexAgent {
     }
 
     fn get_thread(&self, session_id: &SessionId) -> Result<Arc<Thread>, Error> {
-        Ok(self
-            .sessions
-            .lock()
-            .unwrap()
-            .get(session_id)
-            .ok_or_else(|| Error::resource_not_found(None))?
-            .clone())
+        self.loaded_thread(session_id)
+            .ok_or_else(|| Error::resource_not_found(None))
+    }
+
+    fn loaded_thread(&self, session_id: &SessionId) -> Option<Arc<Thread>> {
+        self.sessions.lock().unwrap().get(session_id).cloned()
     }
 
     async fn check_auth(&self) -> Result<(), Error> {
@@ -843,20 +850,21 @@ impl CodexAgent {
     async fn set_session_title(
         &self,
         args: SetSessionTitleRequest,
+        notify_client: impl FnOnce(SessionNotification) -> Result<(), Error>,
     ) -> Result<SetSessionTitleResponse, Error> {
         info!("Setting session title for session: {}", args.session_id);
 
-        let thread = self.get_thread(&args.session_id)?;
-        let thread_id =
-            ThreadId::from_string(&args.session_id.0).map_err(Error::into_internal_error)?;
+        let session_id = args.session_id;
+        let title = args.title;
+        let thread_id = ThreadId::from_string(&session_id.0).map_err(Error::into_internal_error)?;
 
         if let Some(state_db) = self.state_db.as_deref() {
-            match state_db.update_thread_title(thread_id, &args.title).await {
+            match state_db.update_thread_title(thread_id, &title).await {
                 Ok(true) => {}
                 Ok(false) => {
                     debug!(
                         "Thread metadata unavailable before title update for session: {}",
-                        args.session_id
+                        session_id
                     );
                 }
                 Err(err) => {
@@ -866,7 +874,19 @@ impl CodexAgent {
             }
         }
 
-        thread.set_title(args.title).await?;
+        if let Some(thread) = self.loaded_thread(&session_id) {
+            thread.set_title(title).await?;
+        } else {
+            append_thread_name(&self.config.codex_home, thread_id, &title)
+                .await
+                .map_err(|err| {
+                    Error::internal_error().data(format!("failed to index thread title: {err}"))
+                })?;
+            notify_client(SessionNotification::new(
+                session_id,
+                SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new().title(title)),
+            ))?;
+        }
 
         Ok(SetSessionTitleResponse::default())
     }
@@ -992,6 +1012,12 @@ fn stored_session_title(name: Option<&str>, preview: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use acp::schema::MaybeUndefined;
+    use codex_core::config::ConfigOverrides;
+    use uuid::Uuid;
+
     use super::*;
 
     #[test]
@@ -1012,5 +1038,61 @@ mod tests {
             stored_session_title(Some("  "), "preview"),
             Some("preview".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn set_session_title_persists_unloaded_session() -> anyhow::Result<()> {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-unloaded-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        config.codex_home = codex_home.clone().try_into()?;
+
+        let agent = CodexAgent::new(config, None).await?;
+        let thread_id = ThreadId::default();
+        let session_id = SessionId::new(thread_id.to_string());
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let captured_notifications = notifications.clone();
+
+        agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id.clone(), "Renamed historical session"),
+                |notification| {
+                    captured_notifications.lock().unwrap().push(notification);
+                    Ok(())
+                },
+            )
+            .await?;
+
+        assert_eq!(
+            codex_core::find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
+            Some("Renamed historical session".to_string())
+        );
+
+        let notifications = notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|notification| {
+                notification.session_id == session_id
+                    && matches!(
+                        &notification.update,
+                        SessionUpdate::SessionInfoUpdate(update)
+                            if matches!(
+                                &update.title,
+                                MaybeUndefined::Value(title) if title == "Renamed historical session"
+                            )
+                    )
+            }),
+            "expected SessionInfoUpdate for unloaded rename; got: {notifications:#?}"
+        );
+        drop(notifications);
+
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
     }
 }

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -1088,6 +1088,7 @@ mod tests {
 
     use acp::schema::MaybeUndefined;
     use codex_core::config::ConfigOverrides;
+    use codex_core::find_thread_name_by_id;
     use uuid::Uuid;
 
     use super::*;

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -1050,11 +1050,7 @@ fn stored_session_title(name: Option<&str>, preview: &str) -> Option<String> {
 }
 
 fn notification_title_for_update(title: &str) -> Option<String> {
-    if title.trim().is_empty() {
-        None
-    } else {
-        Some(title.to_string())
-    }
+    format_session_title(title)
 }
 
 #[cfg(test)]
@@ -1091,6 +1087,19 @@ mod tests {
     #[test]
     fn stored_session_title_preserves_explicitly_cleared_name() {
         assert_eq!(stored_session_title(Some("  "), "preview"), None);
+    }
+
+    #[test]
+    fn notification_title_for_update_matches_session_list_formatting() {
+        assert_eq!(
+            notification_title_for_update("  custom\ntitle  "),
+            Some("custom title".to_string())
+        );
+        assert_eq!(notification_title_for_update("   "), None);
+
+        let long_title = "a".repeat(SESSION_TITLE_MAX_GRAPHEMES + 1);
+        let expected = format!("{}...", "a".repeat(SESSION_TITLE_MAX_GRAPHEMES - 3));
+        assert_eq!(notification_title_for_update(&long_title), Some(expected));
     }
 
     fn write_minimal_rollout_with_id(

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -41,7 +41,7 @@ use std::{
 use tracing::{debug, info};
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::thread::Thread;
+use crate::thread::{Thread, ThreadOptions};
 
 /// The Codex implementation of the ACP Agent.
 ///
@@ -610,7 +610,10 @@ impl CodexAgent {
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
-            config.clone(),
+            ThreadOptions {
+                config: config.clone(),
+                state_db: self.state_db.clone(),
+            },
             cx,
         ));
         let load = thread.load().await?;
@@ -724,7 +727,10 @@ impl CodexAgent {
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
-            config.clone(),
+            ThreadOptions {
+                config: config.clone(),
+                state_db: self.state_db.clone(),
+            },
             cx,
         ));
 

--- a/src/codex_agent.rs
+++ b/src/codex_agent.rs
@@ -857,10 +857,14 @@ impl CodexAgent {
         let session_id = args.session_id;
         let title = args.title;
         let thread_id = ThreadId::from_string(&session_id.0).map_err(Error::into_internal_error)?;
+        let loaded_thread = self.loaded_thread(&session_id);
+        let mut title_updated_in_state = false;
 
         if let Some(state_db) = self.state_db.as_deref() {
             match state_db.update_thread_title(thread_id, &title).await {
-                Ok(true) => {}
+                Ok(true) => {
+                    title_updated_in_state = true;
+                }
                 Ok(false) => {
                     debug!(
                         "Thread metadata unavailable before title update for session: {}",
@@ -874,9 +878,37 @@ impl CodexAgent {
             }
         }
 
-        if let Some(thread) = self.loaded_thread(&session_id) {
+        if let Some(thread) = loaded_thread {
             thread.set_title(title).await?;
         } else {
+            if !title_updated_in_state {
+                let rollout_path = find_thread_path_by_id_str(
+                    &self.config.codex_home,
+                    session_id.0.as_ref(),
+                    self.state_db.as_deref(),
+                )
+                .await
+                .map_err(|err| {
+                    Error::internal_error().data(format!(
+                        "failed to locate thread before title update: {err}"
+                    ))
+                })?;
+
+                if rollout_path.is_none() {
+                    return Err(Error::resource_not_found(None));
+                }
+
+                if let Some(state_db) = self.state_db.as_deref() {
+                    match state_db.update_thread_title(thread_id, &title).await {
+                        Ok(_) => {}
+                        Err(err) => {
+                            return Err(Error::internal_error()
+                                .data(format!("failed to update thread title: {err}")));
+                        }
+                    }
+                }
+            }
+
             append_thread_name(&self.config.codex_home, thread_id, &title)
                 .await
                 .map_err(|err| {
@@ -1012,7 +1044,11 @@ fn stored_session_title(name: Option<&str>, preview: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        io::Write,
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+    };
 
     use acp::schema::MaybeUndefined;
     use codex_core::config::ConfigOverrides;
@@ -1040,6 +1076,32 @@ mod tests {
         );
     }
 
+    fn write_minimal_rollout_with_id(codex_home: &Path, id: Uuid) -> anyhow::Result<PathBuf> {
+        let sessions = codex_home.join("sessions/2024/01/01");
+        std::fs::create_dir_all(&sessions)?;
+
+        let file = sessions.join(format!("rollout-2024-01-01T00-00-00-{id}.jsonl"));
+        let mut writer = std::fs::File::create(&file)?;
+        writeln!(
+            writer,
+            "{}",
+            serde_json::json!({
+                "timestamp": "2024-01-01T00:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": id.to_string(),
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "cwd": ".",
+                    "originator": "test",
+                    "cli_version": "test",
+                    "model_provider": "test-provider"
+                }
+            })
+        )?;
+
+        Ok(file)
+    }
+
     #[tokio::test]
     async fn set_session_title_persists_unloaded_session() -> anyhow::Result<()> {
         let codex_home =
@@ -1054,7 +1116,9 @@ mod tests {
         config.codex_home = codex_home.clone().try_into()?;
 
         let agent = CodexAgent::new(config, None).await?;
-        let thread_id = ThreadId::default();
+        let thread_uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
+        write_minimal_rollout_with_id(&codex_home, thread_uuid)?;
         let session_id = SessionId::new(thread_id.to_string());
         let notifications = Arc::new(Mutex::new(Vec::new()));
         let captured_notifications = notifications.clone();
@@ -1090,6 +1154,51 @@ mod tests {
             "expected SessionInfoUpdate for unloaded rename; got: {notifications:#?}"
         );
         drop(notifications);
+
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_session_title_rejects_missing_unloaded_session() -> anyhow::Result<()> {
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-missing-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        config.codex_home = codex_home.clone().try_into()?;
+
+        let agent = CodexAgent::new(config, None).await?;
+        let thread_id = ThreadId::default();
+        let session_id = SessionId::new(thread_id.to_string());
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let captured_notifications = notifications.clone();
+
+        let result = agent
+            .set_session_title(
+                SetSessionTitleRequest::new(session_id, "Orphan title"),
+                |notification| {
+                    captured_notifications.lock().unwrap().push(notification);
+                    Ok(())
+                },
+            )
+            .await;
+
+        let err = match result {
+            Ok(_) => panic!("expected missing unloaded session to be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
+        assert_eq!(
+            codex_core::find_thread_name_by_id(&agent.config.codex_home, &thread_id).await?,
+            None
+        );
+        assert!(notifications.lock().unwrap().is_empty());
 
         std::fs::remove_dir_all(codex_home).ok();
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -84,6 +84,7 @@ use itertools::Itertools;
 use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
+use unicode_segmentation::UnicodeSegmentation;
 use uuid::Uuid;
 
 /// Abstraction over the ACP connection for sending notifications and requests
@@ -114,6 +115,7 @@ impl ClientSender for AcpConnection {
 
 static APPROVAL_PRESETS: LazyLock<Vec<ApprovalPreset>> = LazyLock::new(builtin_approval_presets);
 const INIT_COMMAND_PROMPT: &str = include_str!("./prompt_for_init_command.md");
+const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
 const CODEX_READ_ONLY_PROFILE_ID: &str = ":read-only";
 const CODEX_WORKSPACE_PROFILE_ID: &str = ":workspace";
 const CODEX_DANGER_NO_SANDBOX_PROFILE_ID: &str = ":danger-no-sandbox";
@@ -208,6 +210,40 @@ fn current_session_mode_id(config: &Config) -> Option<SessionModeId> {
 
 fn mode_trusts_project(mode_id: &str) -> bool {
     matches!(mode_id, "auto" | "full-access")
+}
+
+fn truncate_title_graphemes(text: &str, max_graphemes: usize) -> String {
+    let mut graphemes = text.grapheme_indices(true);
+
+    if let Some((byte_index, _)) = graphemes.nth(max_graphemes) {
+        if max_graphemes >= 3 {
+            let mut truncate_graphemes = text.grapheme_indices(true);
+            if let Some((truncate_byte_index, _)) = truncate_graphemes.nth(max_graphemes - 3) {
+                let truncated = &text[..truncate_byte_index];
+                format!("{truncated}...")
+            } else {
+                text.to_string()
+            }
+        } else {
+            let truncated = &text[..byte_index];
+            truncated.to_string()
+        }
+    } else {
+        text.to_string()
+    }
+}
+
+fn notification_title_for_rename(title: &str) -> Option<String> {
+    let normalized = title.replace(['\r', '\n'], " ");
+    let trimmed = normalized.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(truncate_title_graphemes(
+            trimmed,
+            SESSION_TITLE_MAX_GRAPHEMES,
+        ))
+    }
 }
 
 /// Trait for abstracting over the `CodexThread` to make testing easier.
@@ -3292,8 +3328,9 @@ impl<A: Auth> ThreadActor<A> {
                         self.client
                             .send_agent_text("Usage: /rename <new session title>\n");
                     } else {
+                        let notification_title = notification_title_for_rename(title);
                         match self
-                            .handle_set_title(title.to_owned(), Some(title.to_owned()))
+                            .handle_set_title(title.to_owned(), notification_title)
                             .await
                         {
                             Ok(()) => self
@@ -4422,6 +4459,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rename_notification_title_matches_session_list_formatting() {
+        assert_eq!(
+            notification_title_for_rename("  custom\ntitle  "),
+            Some("custom title".to_string())
+        );
+        assert_eq!(notification_title_for_rename("   "), None);
+
+        let long_title = "a".repeat(SESSION_TITLE_MAX_GRAPHEMES + 1);
+        let expected = format!("{}...", "a".repeat(SESSION_TITLE_MAX_GRAPHEMES - 3));
+        assert_eq!(notification_title_for_rename(&long_title), Some(expected));
+    }
+
     #[tokio::test]
     async fn slash_rename_without_arg_shows_usage_message() -> anyhow::Result<()> {
         let (session_id, client, _thread, message_tx, _handle) = setup().await?;
@@ -4508,7 +4558,7 @@ mod tests {
         message_tx.send(ThreadMessage::Prompt {
             request: PromptRequest::new(
                 session_id.clone(),
-                vec!["/rename Quarterly review thread".into()],
+                vec!["/rename Quarterly\nreview thread".into()],
             ),
             response_tx: prompt_response_tx,
         })?;
@@ -4519,22 +4569,34 @@ mod tests {
 
         assert_eq!(
             codex_core::find_thread_name_by_id(&codex_home_abs, &thread_id).await?,
-            Some("Quarterly review thread".to_string())
+            Some("Quarterly\nreview thread".to_string())
         );
         let metadata = state_db
             .get_thread(thread_id)
             .await?
             .expect("state DB should keep the renamed thread metadata");
-        assert_eq!(metadata.title, "Quarterly review thread");
+        assert_eq!(metadata.title, "Quarterly\nreview thread");
 
         let notifications = client.notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|notification| matches!(
+                &notification.update,
+                SessionUpdate::SessionInfoUpdate(update)
+                    if matches!(
+                        &update.title,
+                        agent_client_protocol::schema::MaybeUndefined::Value(title)
+                            if title == "Quarterly review thread"
+                    )
+            )),
+            "expected a normalized SessionInfoUpdate for `/rename`; got: {notifications:#?}"
+        );
         assert!(
             notifications.iter().any(|notification| matches!(
                 &notification.update,
                 SessionUpdate::AgentMessageChunk(ContentChunk {
                     content: ContentBlock::Text(TextContent { text, .. }),
                     ..
-                }) if text.contains("Renamed session to") && text.contains("Quarterly review thread")
+                }) if text.contains("Renamed session to") && text.contains("Quarterly\nreview thread")
             )),
             "expected a confirmation message for `/rename`; got: {notifications:#?}"
         );

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -26,7 +26,7 @@ use agent_client_protocol::{
 };
 use codex_apply_patch::parse_patch;
 use codex_core::{
-    CodexThread,
+    CodexThread, append_thread_name,
     config::{Config, set_project_trust_level},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
@@ -34,6 +34,7 @@ use codex_core::{
 use codex_login::auth::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::{
+    ThreadId,
     approvals::{
         ElicitationRequest, ElicitationRequestEvent, GuardianAssessmentAction,
         GuardianCommandSource,
@@ -284,6 +285,10 @@ enum ThreadMessage {
         mode: SessionModeId,
         response_tx: oneshot::Sender<Result<(), Error>>,
     },
+    SetTitle {
+        title: String,
+        response_tx: oneshot::Sender<Result<(), Error>>,
+    },
     SetConfigOption {
         config_id: SessionConfigId,
         value: SessionConfigOptionValue,
@@ -390,6 +395,20 @@ impl Thread {
         let (response_tx, response_rx) = oneshot::channel();
 
         let message = ThreadMessage::SetMode { mode, response_tx };
+        drop(self.message_tx.send(message));
+
+        response_rx
+            .await
+            .map_err(|e| Error::internal_error().data(e.to_string()))?
+    }
+
+    pub async fn set_title(&self, title: impl Into<String>) -> Result<(), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let message = ThreadMessage::SetTitle {
+            title: title.into(),
+            response_tx,
+        };
         drop(self.message_tx.send(message));
 
         response_rx
@@ -2848,6 +2867,10 @@ impl<A: Auth> ThreadActor<A> {
                 drop(response_tx.send(result));
                 self.maybe_emit_config_options_update().await;
             }
+            ThreadMessage::SetTitle { title, response_tx } => {
+                let result = self.handle_set_title(title).await;
+                drop(response_tx.send(result));
+            }
             ThreadMessage::SetConfigOption {
                 config_id,
                 value,
@@ -3317,6 +3340,19 @@ impl<A: Auth> ThreadActor<A> {
                 TrustLevel::Trusted,
             )?;
         }
+
+        Ok(())
+    }
+
+    async fn handle_set_title(&mut self, title: String) -> Result<(), Error> {
+        let thread_id =
+            ThreadId::from_string(&self.client.session_id.0).map_err(Error::into_internal_error)?;
+
+        append_thread_name(&self.config.codex_home, thread_id, &title)
+            .await
+            .map_err(|err| {
+                Error::internal_error().data(format!("failed to index thread title: {err}"))
+            })?;
 
         Ok(())
     }
@@ -4667,6 +4703,57 @@ mod tests {
 
         let handle = tokio::spawn(actor.spawn());
         Ok((session_id, client, conversation, message_tx, handle))
+    }
+
+    #[tokio::test]
+    async fn test_set_session_title_renames_underlying_thread() -> anyhow::Result<()> {
+        let thread_id = ThreadId::default();
+        let session_id = SessionId::new(thread_id.to_string());
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let codex_home = std::env::temp_dir().join(format!("codex-acp-title-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+        config.codex_home = codex_home.clone().try_into()?;
+        let codex_home_abs = config.codex_home.clone();
+
+        let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation.clone(),
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
+        let thread = Thread {
+            thread: conversation,
+            message_tx,
+            _handle: tokio::spawn(actor.spawn()),
+        };
+
+        thread.set_title("Renamed from ACP").await?;
+
+        assert_eq!(
+            codex_core::find_thread_name_by_id(&codex_home_abs, &thread_id).await?,
+            Some("Renamed from ACP".to_string())
+        );
+
+        thread.shutdown().await?;
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
     }
 
     struct StubAuth;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -287,6 +287,7 @@ enum ThreadMessage {
     },
     SetTitle {
         title: String,
+        notification_title: Option<String>,
         response_tx: oneshot::Sender<Result<(), Error>>,
     },
     SetConfigOption {
@@ -402,11 +403,16 @@ impl Thread {
             .map_err(|e| Error::internal_error().data(e.to_string()))?
     }
 
-    pub async fn set_title(&self, title: impl Into<String>) -> Result<(), Error> {
+    pub async fn set_title(
+        &self,
+        title: impl Into<String>,
+        notification_title: Option<String>,
+    ) -> Result<(), Error> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let message = ThreadMessage::SetTitle {
             title: title.into(),
+            notification_title,
             response_tx,
         };
         drop(self.message_tx.send(message));
@@ -2867,8 +2873,12 @@ impl<A: Auth> ThreadActor<A> {
                 drop(response_tx.send(result));
                 self.maybe_emit_config_options_update().await;
             }
-            ThreadMessage::SetTitle { title, response_tx } => {
-                let result = self.handle_set_title(title).await;
+            ThreadMessage::SetTitle {
+                title,
+                notification_title,
+                response_tx,
+            } => {
+                let result = self.handle_set_title(title, notification_title).await;
                 drop(response_tx.send(result));
             }
             ThreadMessage::SetConfigOption {
@@ -3344,7 +3354,11 @@ impl<A: Auth> ThreadActor<A> {
         Ok(())
     }
 
-    async fn handle_set_title(&mut self, title: String) -> Result<(), Error> {
+    async fn handle_set_title(
+        &mut self,
+        title: String,
+        notification_title: Option<String>,
+    ) -> Result<(), Error> {
         let thread_id =
             ThreadId::from_string(&self.client.session_id.0).map_err(Error::into_internal_error)?;
 
@@ -3358,7 +3372,7 @@ impl<A: Auth> ThreadActor<A> {
         // session list without waiting for the next session/list call.
         self.client
             .send_notification(SessionUpdate::SessionInfoUpdate(
-                SessionInfoUpdate::new().title(title),
+                SessionInfoUpdate::new().title(notification_title),
             ));
 
         Ok(())
@@ -4750,7 +4764,9 @@ mod tests {
             _handle: tokio::spawn(actor.spawn()),
         };
 
-        thread.set_title("Renamed from ACP").await?;
+        thread
+            .set_title("Renamed from ACP", Some("Renamed from ACP".to_string()))
+            .await?;
 
         assert_eq!(
             codex_core::find_thread_name_by_id(&codex_home_abs, &thread_id).await?,
@@ -4766,6 +4782,66 @@ mod tests {
                         if matches!(&update.title, agent_client_protocol::schema::MaybeUndefined::Value(t) if t == "Renamed from ACP")
                 )),
                 "expected a SessionInfoUpdate carrying the new title; got: {notifications:#?}"
+            );
+        }
+
+        thread.shutdown().await?;
+        std::fs::remove_dir_all(codex_home).ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_set_session_title_clear_emits_null_title() -> anyhow::Result<()> {
+        let thread_id = ThreadId::default();
+        let session_id = SessionId::new(thread_id.to_string());
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let codex_home = std::env::temp_dir().join(format!("codex-acp-clear-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+        config.codex_home = codex_home.clone().try_into()?;
+
+        let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation.clone(),
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
+        let thread = Thread {
+            thread: conversation,
+            message_tx,
+            _handle: tokio::spawn(actor.spawn()),
+        };
+
+        thread.set_title("   ", None).await?;
+
+        {
+            let notifications = client.notifications.lock().unwrap();
+            assert!(
+                notifications.iter().any(|n| matches!(
+                    &n.update,
+                    SessionUpdate::SessionInfoUpdate(update)
+                        if matches!(
+                            &update.title,
+                            agent_client_protocol::schema::MaybeUndefined::Null
+                        )
+                )),
+                "expected a SessionInfoUpdate clearing the title; got: {notifications:#?}"
             );
         }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4757,16 +4757,17 @@ mod tests {
             Some("Renamed from ACP".to_string())
         );
 
-        let notifications = client.notifications.lock().unwrap();
-        assert!(
-            notifications.iter().any(|n| matches!(
-                &n.update,
-                SessionUpdate::SessionInfoUpdate(update)
-                    if matches!(&update.title, agent_client_protocol::schema::MaybeUndefined::Value(t) if t == "Renamed from ACP")
-            )),
-            "expected a SessionInfoUpdate carrying the new title; got: {notifications:#?}"
-        );
-        drop(notifications);
+        {
+            let notifications = client.notifications.lock().unwrap();
+            assert!(
+                notifications.iter().any(|n| matches!(
+                    &n.update,
+                    SessionUpdate::SessionInfoUpdate(update)
+                        if matches!(&update.title, agent_client_protocol::schema::MaybeUndefined::Value(t) if t == "Renamed from ACP")
+                )),
+                "expected a SessionInfoUpdate carrying the new title; got: {notifications:#?}"
+            );
+        }
 
         thread.shutdown().await?;
         std::fs::remove_dir_all(codex_home).ok();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -17,8 +17,8 @@ use agent_client_protocol::{
         RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
         ResourceLink, SelectedPermissionOutcome, SessionConfigId, SessionConfigOption,
         SessionConfigOptionCategory, SessionConfigOptionValue, SessionConfigSelectOption,
-        SessionConfigValueId, SessionId, SessionMode, SessionModeId, SessionModeState,
-        SessionNotification, SessionUpdate, StopReason, Terminal, TextContent,
+        SessionConfigValueId, SessionId, SessionInfoUpdate, SessionMode, SessionModeId,
+        SessionModeState, SessionNotification, SessionUpdate, StopReason, Terminal, TextContent,
         TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation,
         ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
         UsageUpdate,
@@ -3354,6 +3354,13 @@ impl<A: Auth> ThreadActor<A> {
                 Error::internal_error().data(format!("failed to index thread title: {err}"))
             })?;
 
+        // Tell the connected client the title changed so it can repaint the
+        // session list without waiting for the next session/list call.
+        self.client
+            .send_notification(SessionUpdate::SessionInfoUpdate(
+                SessionInfoUpdate::new().title(title),
+            ));
+
         Ok(())
     }
 
@@ -4749,6 +4756,17 @@ mod tests {
             codex_core::find_thread_name_by_id(&codex_home_abs, &thread_id).await?,
             Some("Renamed from ACP".to_string())
         );
+
+        let notifications = client.notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|n| matches!(
+                &n.update,
+                SessionUpdate::SessionInfoUpdate(update)
+                    if matches!(&update.title, agent_client_protocol::schema::MaybeUndefined::Value(t) if t == "Renamed from ACP")
+            )),
+            "expected a SessionInfoUpdate carrying the new title; got: {notifications:#?}"
+        );
+        drop(notifications);
 
         thread.shutdown().await?;
         std::fs::remove_dir_all(codex_home).ok();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -26,7 +26,7 @@ use agent_client_protocol::{
 };
 use codex_apply_patch::parse_patch;
 use codex_core::{
-    CodexThread, append_thread_name,
+    CodexThread, StateDbHandle, append_thread_name,
     config::{Config, set_project_trust_level},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
@@ -322,14 +322,19 @@ pub struct Thread {
     _handle: tokio::task::JoinHandle<()>,
 }
 
+pub(crate) struct ThreadOptions {
+    pub(crate) config: Config,
+    pub(crate) state_db: Option<StateDbHandle>,
+}
+
 impl Thread {
-    pub fn new(
+    pub(crate) fn new(
         session_id: SessionId,
         thread: Arc<dyn CodexThreadImpl>,
         auth: Arc<AuthManager>,
         models_manager: Arc<dyn ModelsManagerImpl>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
-        config: Config,
+        options: ThreadOptions,
         cx: ConnectionTo<Client>,
     ) -> Self {
         let (message_tx, message_rx) = mpsc::unbounded_channel();
@@ -340,7 +345,8 @@ impl Thread {
             SessionClient::new(session_id, cx, client_capabilities),
             thread.clone(),
             models_manager,
-            config,
+            options.config,
+            options.state_db,
             message_rx,
             resolution_tx,
             resolution_rx,
@@ -2772,6 +2778,8 @@ struct ThreadActor<A> {
     thread: Arc<dyn CodexThreadImpl>,
     /// The configuration for the thread.
     config: Config,
+    /// Optional SQLite state DB used for DB-backed session metadata updates.
+    state_db: Option<StateDbHandle>,
     /// The models available for this thread.
     models_manager: Arc<dyn ModelsManagerImpl>,
     /// Internal message sender used to route spawned interaction results back to the actor.
@@ -2794,6 +2802,7 @@ impl<A: Auth> ThreadActor<A> {
         thread: Arc<dyn CodexThreadImpl>,
         models_manager: Arc<dyn ModelsManagerImpl>,
         config: Config,
+        state_db: Option<StateDbHandle>,
         message_rx: mpsc::UnboundedReceiver<ThreadMessage>,
         resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
         resolution_rx: mpsc::UnboundedReceiver<ThreadMessage>,
@@ -2803,6 +2812,7 @@ impl<A: Auth> ThreadActor<A> {
             client,
             thread,
             config,
+            state_db,
             models_manager,
             resolution_tx,
             submissions: HashMap::new(),
@@ -2963,6 +2973,11 @@ impl<A: Auth> ThreadActor<A> {
                 "summarize conversation to prevent hitting the context limit",
             ),
             AvailableCommand::new("logout", "logout of Codex"),
+            AvailableCommand::new("rename", "rename this session").input(
+                AvailableCommandInput::Unstructured(UnstructuredCommandInput::new(
+                    "new session title",
+                )),
+            ),
         ]
     }
 
@@ -3271,6 +3286,28 @@ impl<A: Auth> ThreadActor<A> {
                     self.auth.logout().await?;
                     return Err(Error::auth_required());
                 }
+                "rename" => {
+                    let title = rest.trim();
+                    if title.is_empty() {
+                        self.client
+                            .send_agent_text("Usage: /rename <new session title>\n");
+                    } else {
+                        match self
+                            .handle_set_title(title.to_owned(), Some(title.to_owned()))
+                            .await
+                        {
+                            Ok(()) => self
+                                .client
+                                .send_agent_text(format!("Renamed session to \"{title}\".\n")),
+                            Err(err) => self.client.send_agent_text(format!(
+                                "Failed to rename session: {}\n",
+                                err.message
+                            )),
+                        }
+                    }
+                    drop(response_tx.send(Ok(StopReason::EndTurn)));
+                    return Ok(response_rx);
+                }
                 _ => {
                     op = Op::UserInput {
                         items,
@@ -3361,6 +3398,15 @@ impl<A: Auth> ThreadActor<A> {
     ) -> Result<(), Error> {
         let thread_id =
             ThreadId::from_string(&self.client.session_id.0).map_err(Error::into_internal_error)?;
+
+        if let Some(state_db) = self.state_db.as_deref() {
+            state_db
+                .update_thread_title(thread_id, &title)
+                .await
+                .map_err(|err| {
+                    Error::internal_error().data(format!("failed to update thread title: {err}"))
+                })?;
+        }
 
         append_thread_name(&self.config.codex_home, thread_id, &title)
             .await
@@ -4162,7 +4208,8 @@ fn extract_slash_command(content: &[UserInput]) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
-    use std::path::PathBuf;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
@@ -4174,6 +4221,32 @@ mod tests {
     use tokio::sync::{Mutex, Notify, mpsc::UnboundedSender};
 
     use super::*;
+
+    fn write_minimal_rollout_with_id(codex_home: &Path, id: Uuid) -> anyhow::Result<PathBuf> {
+        let sessions = codex_home.join("sessions/2024/01/01");
+        std::fs::create_dir_all(&sessions)?;
+
+        let file = sessions.join(format!("rollout-2024-01-01T00-00-00-{id}.jsonl"));
+        let mut writer = std::fs::File::create(&file)?;
+        writeln!(
+            writer,
+            "{}",
+            serde_json::json!({
+                "timestamp": "2024-01-01T00:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": id.to_string(),
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "cwd": ".",
+                    "originator": "test",
+                    "cli_version": "test",
+                    "model_provider": "test-provider"
+                }
+            })
+        )?;
+
+        Ok(file)
+    }
 
     #[tokio::test]
     async fn test_prompt() -> anyhow::Result<()> {
@@ -4333,6 +4406,140 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(ops.as_slice(), &[Op::Compact]);
 
+        Ok(())
+    }
+
+    #[test]
+    fn rename_is_listed_in_builtin_commands() {
+        let commands = ThreadActor::<StubAuth>::builtin_commands();
+        let rename = commands
+            .iter()
+            .find(|c| c.name == "rename")
+            .expect("rename builtin should be exposed");
+        assert!(
+            rename.input.is_some(),
+            "rename should advertise an unstructured input field for the new title"
+        );
+    }
+
+    #[tokio::test]
+    async fn slash_rename_without_arg_shows_usage_message() -> anyhow::Result<()> {
+        let (session_id, client, _thread, message_tx, _handle) = setup().await?;
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id.clone(), vec!["/rename".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let stop_reason = prompt_response_rx.await??.await??;
+        assert_eq!(stop_reason, StopReason::EndTurn);
+        drop(message_tx);
+
+        let notifications = client.notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|notification| matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text.contains("Usage: /rename")
+            )),
+            "expected a usage message for `/rename` with no argument; got: {notifications:#?}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn slash_rename_with_arg_writes_title_to_session_index_and_state_db() -> anyhow::Result<()>
+    {
+        let thread_uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&thread_uuid.to_string())?;
+        let session_id = SessionId::new(thread_id.to_string());
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let codex_home =
+            std::env::temp_dir().join(format!("codex-acp-slash-rename-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&codex_home)?;
+        config.codex_home = codex_home.clone().try_into()?;
+        let codex_home_abs = config.codex_home.clone();
+        let state_db = codex_core::init_state_db(&config)
+            .await
+            .expect("test config should initialize a state DB");
+        write_minimal_rollout_with_id(&codex_home, thread_uuid)?;
+        let rollout_path = codex_core::find_thread_path_by_id_str(
+            &codex_home_abs,
+            session_id.0.as_ref(),
+            Some(&state_db),
+        )
+        .await?;
+        assert!(rollout_path.is_some());
+        assert!(
+            state_db
+                .update_thread_title(thread_id, "Old DB title")
+                .await?
+        );
+
+        let (message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation.clone(),
+            models_manager,
+            config,
+            Some(state_db.clone()),
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+        let _handle = tokio::spawn(actor.spawn());
+
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(
+                session_id.clone(),
+                vec!["/rename Quarterly review thread".into()],
+            ),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let stop_reason = prompt_response_rx.await??.await??;
+        assert_eq!(stop_reason, StopReason::EndTurn);
+        drop(message_tx);
+
+        assert_eq!(
+            codex_core::find_thread_name_by_id(&codex_home_abs, &thread_id).await?,
+            Some("Quarterly review thread".to_string())
+        );
+        let metadata = state_db
+            .get_thread(thread_id)
+            .await?
+            .expect("state DB should keep the renamed thread metadata");
+        assert_eq!(metadata.title, "Quarterly review thread");
+
+        let notifications = client.notifications.lock().unwrap();
+        assert!(
+            notifications.iter().any(|notification| matches!(
+                &notification.update,
+                SessionUpdate::AgentMessageChunk(ContentChunk {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) if text.contains("Renamed session to") && text.contains("Quarterly review thread")
+            )),
+            "expected a confirmation message for `/rename`; got: {notifications:#?}"
+        );
+
+        std::fs::remove_dir_all(codex_home).ok();
         Ok(())
     }
 
@@ -4717,6 +4924,7 @@ mod tests {
             conversation.clone(),
             models_manager,
             config,
+            None,
             message_rx,
             resolution_tx,
             resolution_rx,
@@ -4753,6 +4961,7 @@ mod tests {
             conversation.clone(),
             models_manager,
             config,
+            None,
             message_rx,
             resolution_tx,
             resolution_rx,
@@ -4817,6 +5026,7 @@ mod tests {
             conversation.clone(),
             models_manager,
             config,
+            None,
             message_rx,
             resolution_tx,
             resolution_rx,
@@ -5824,6 +6034,7 @@ mod tests {
             conversation.clone(),
             models_manager,
             config,
+            None,
             message_rx,
             resolution_tx,
             resolution_rx,


### PR DESCRIPTION
## Summary

Adds `/rename <new title>` as a builtin slash command for codex-acp. Typing `/rename Foo` in any ACP client (including stock Zed.app -- no client-side change required) renames the current session: the title is persisted to `session_index.jsonl`, the SQLite state DB is updated, and the client repaints its session list inline via the `SessionInfoUpdate` notification.

Empty argument prints a usage hint instead of being a silent no-op. The new builtin is added to `builtin_command_names()` so a same-named skill cannot shadow it.

## Why

Today users can rename a session only by opening the title editor in the agent panel header, which depends on Zed having merged the title-editor wiring and on the protocol/handler PRs landing. A slash command works from any ACP client immediately because the dispatch lives entirely inside codex-acp.

## What's in this PR

- `thread.rs`:
  - Adds `rename` to `builtin_command_names()` and `builtin_commands()` with an `Unstructured("new session title")` input hint so the `/` picker shows the argument slot.
  - In `handle_prompt`, intercepts `/rename` before the `Op::UserInput` dispatch. Empty arg -> `Usage:` agent message. Non-empty -> calls `self.handle_set_title(title, Some(title))`, which already persists + emits `SessionInfoUpdate`, then sends a confirmation chunk. Returns `StopReason::EndTurn` immediately and never reaches the model.
- New unit tests: `rename_is_listed_in_builtin_commands`, `slash_rename_without_arg_shows_usage_message`, `slash_rename_with_arg_writes_title_to_session_index`.

## Tests

```text
cargo fmt --all -- --check
cargo test --locked --lib
cargo check --locked
cargo clippy --all-targets --all-features -- -D warnings
git diff --check
```

37 lib tests pass.

## Dependencies (drafted until merged)

This PR is intentionally split out as a separate, smaller concern from the underlying rename infrastructure. It stacks on:

- #279 -- Expose Codex skills as ACP slash commands.
- #286 -- Handle session/setTitle and emit SessionInfoUpdate.
- agentclientprotocol/agent-client-protocol#1199 -- the protocol-level companion.

I'll mark this PR ready-for-review and rebase to a clean single-commit diff once the dependencies land.
